### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is an Android app (Gradle Kotlin DSL, AGP 9.1.1, Kotlin 2.2.10, JDK 21,
+`compileSdk`/`targetSdk` 37, `minSdk` 26). Standard build/run commands are in
+`README.md` and `.github/workflows/ci.yml`.
+
+### Environment (already provisioned in the VM snapshot)
+- Android SDK lives at `/opt/android-sdk` (`platforms;android-37.0`,
+  `build-tools;37.0.0`, `platform-tools`). `ANDROID_HOME`/`ANDROID_SDK_ROOT` are
+  exported from `~/.bashrc`.
+- `local.properties` (gitignored) already contains `sdk.dir=/opt/android-sdk`.
+- There is **no KVM / Android emulator** in this VM, so the app cannot be launched
+  on a device here. Validate changes the same way CI does: unit tests + a debug APK
+  build. Instrumented (`androidTest`) tests cannot run.
+
+### Build & test
+- Debug APK (fastest — single ABI): `./gradlew :app:assembleDebug -Ponionphone.devAbi=arm64-v8a --no-daemon`
+  → `app/build/outputs/apk/debug/app-debug.apk`.
+- Unit tests: `./gradlew test --no-daemon`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `AGENTS.md` documenting the Cursor Cloud development environment for this repo. No source/build changes.

Dev environment set up and verified: Android SDK at `/opt/android-sdk` (`platforms;android-37.0`, `build-tools;37.0.0`, `platform-tools`) on JDK 21; `local.properties` (gitignored) points at the SDK.

## Verification
- ✅ `./gradlew :app:assembleDebug -Ponionphone.devAbi=arm64-v8a --no-daemon` → `app/build/outputs/apk/debug/app-debug.apk`
- ✅ `./gradlew test --no-daemon` (0 failures)

## Notes captured in AGENTS.md
- No KVM/emulator in the VM → validate via unit tests + debug APK build (same as CI).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f23e0b13-4a28-4aca-8b03-9bd766ce4783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f23e0b13-4a28-4aca-8b03-9bd766ce4783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

