### PR TITLE
feat(firewall): domaines + couleurs HaGeZi sur les prompts de connexion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
   dependency-review:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # Soft-fail until Dependency graph is enabled:
+    # Settings → Code security → Dependency graph
+    # (action errors with "Dependency review is not supported" otherwise).
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     ksp(libs.hilt.compiler)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.timber)
+    implementation(libs.okhttp)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.biometric)

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/MainActivity.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/MainActivity.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 import ltechnologies.onionphone.onionvpn.firewall.InteractiveFirewallEngine
 import ltechnologies.onionphone.onionvpn.security.AppLockAuthenticator
 import ltechnologies.onionphone.onionvpn.security.AppLockManager
+import ltechnologies.onionphone.onionvpn.threat.DomainReputationRepository
 import ltechnologies.onionphone.onionvpn.ui.FirewallScreen
 import ltechnologies.onionphone.onionvpn.ui.LogsScreen
 import ltechnologies.onionphone.onionvpn.ui.SettingsScreen
@@ -46,6 +47,7 @@ class MainActivity : FragmentActivity() {
     private val viewModel: MainViewModel by viewModels()
 
     @Inject lateinit var firewallEngine: InteractiveFirewallEngine
+    @Inject lateinit var domainReputation: DomainReputationRepository
     @Inject lateinit var appLockManager: AppLockManager
     @Inject lateinit var appLockAuthenticator: AppLockAuthenticator
 
@@ -85,6 +87,7 @@ class MainActivity : FragmentActivity() {
                         snapshot = snapshot,
                         preferences = preferences,
                         firewallEngine = firewallEngine,
+                        domainReputation = domainReputation,
                         onStart = ::requestNotificationsThenStart,
                         onStop = viewModel::stopTunnel,
                         onNewNym = viewModel::newNym,
@@ -136,6 +139,7 @@ private fun OnionVpnApp(
     snapshot: ltechnologies.onionphone.onionvpn.core.model.TunnelSnapshot,
     preferences: ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences,
     firewallEngine: InteractiveFirewallEngine,
+    domainReputation: DomainReputationRepository,
     onStart: () -> Unit,
     onStop: () -> Unit,
     onNewNym: () -> Unit,
@@ -188,6 +192,7 @@ private fun OnionVpnApp(
                 2 -> LogsScreen()
                 else -> SettingsScreen(
                     preferences = preferences,
+                    domainReputation = domainReputation,
                     onLoadTorrc = onLoadTorrc,
                     onLoadDnsCryptToml = onLoadDnsCryptToml,
                     onSavePreferences = onSavePreferences,

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/OnionVpnApplication.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/OnionVpnApplication.kt
@@ -17,6 +17,7 @@ import ltechnologies.onionphone.onionvpn.logging.LogSource
 import ltechnologies.onionphone.onionvpn.logging.ProcessLogSeverity
 import ltechnologies.onionphone.onionvpn.logging.TunnelLogBuffer
 import ltechnologies.onionphone.onionvpn.logging.TunnelLogTree
+import ltechnologies.onionphone.onionvpn.threat.DomainReputationRepository
 import timber.log.Timber
 
 @HiltAndroidApp
@@ -24,6 +25,7 @@ class OnionVpnApplication : Application() {
     @Inject lateinit var tor: TorProcessManager
     @Inject lateinit var dnsCrypt: DnsCryptProcessManager
     @Inject lateinit var firewallEngine: InteractiveFirewallEngine
+    @Inject lateinit var domainReputation: DomainReputationRepository
 
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -34,6 +36,7 @@ class OnionVpnApplication : Application() {
             Timber.plant(Timber.DebugTree())
         }
         firewallEngine.start()
+        domainReputation.start()
         FirewallBridge.engine = firewallEngine
         tor.onLogLine = { line ->
             val err = ProcessLogSeverity.isError(LogSource.TOR, line)

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptContent.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptContent.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -26,9 +25,6 @@ import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
 import ltechnologies.onionphone.onionvpn.core.model.FirewallConnectionInfo
 import ltechnologies.onionphone.onionvpn.core.model.FirewallRuleScope
 import ltechnologies.onionphone.onionvpn.core.model.FirewallVerdict
-
-private val ThreatOrange = Color(0xFFE65100)
-private val ThreatRed = Color(0xFFC62828)
 
 @Composable
 fun FirewallPromptContent(
@@ -40,16 +36,8 @@ fun FirewallPromptContent(
     val icon = runCatching {
         context.packageManager.getApplicationIcon(info.packageName).toBitmap(96, 96).asImageBitmap()
     }.getOrNull()
-    val destColor = when (info.threatCategory) {
-        DomainThreatCategory.MALWARE -> ThreatRed
-        DomainThreatCategory.TRACKING -> ThreatOrange
-        DomainThreatCategory.NONE -> MaterialTheme.colorScheme.onSurface
-    }
-    val threatLabel = when (info.threatCategory) {
-        DomainThreatCategory.MALWARE -> "Malware / C2"
-        DomainThreatCategory.TRACKING -> "Ads / tracking / telemetry"
-        DomainThreatCategory.NONE -> null
-    }
+    val destColor = threatTextColor(info.threatCategory)
+    val threatLabel = threatLabelOrNull(info.threatCategory)
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptContent.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptContent.kt
@@ -16,13 +16,19 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
 import ltechnologies.onionphone.onionvpn.core.model.FirewallConnectionInfo
 import ltechnologies.onionphone.onionvpn.core.model.FirewallRuleScope
 import ltechnologies.onionphone.onionvpn.core.model.FirewallVerdict
+
+private val ThreatOrange = Color(0xFFE65100)
+private val ThreatRed = Color(0xFFC62828)
 
 @Composable
 fun FirewallPromptContent(
@@ -34,6 +40,16 @@ fun FirewallPromptContent(
     val icon = runCatching {
         context.packageManager.getApplicationIcon(info.packageName).toBitmap(96, 96).asImageBitmap()
     }.getOrNull()
+    val destColor = when (info.threatCategory) {
+        DomainThreatCategory.MALWARE -> ThreatRed
+        DomainThreatCategory.TRACKING -> ThreatOrange
+        DomainThreatCategory.NONE -> MaterialTheme.colorScheme.onSurface
+    }
+    val threatLabel = when (info.threatCategory) {
+        DomainThreatCategory.MALWARE -> "Malware / C2"
+        DomainThreatCategory.TRACKING -> "Ads / tracking / telemetry"
+        DomainThreatCategory.NONE -> null
+    }
 
     Column(
         modifier = Modifier
@@ -74,9 +90,29 @@ fun FirewallPromptContent(
         }
 
         Text(
-            "${info.protocolLabel} → ${info.destIp}:${info.destPort}",
+            "${info.protocolLabel} → ${info.displayDestination()}:${info.destPort}",
             style = MaterialTheme.typography.titleMedium,
+            color = destColor,
+            fontWeight = if (info.threatCategory != DomainThreatCategory.NONE) {
+                FontWeight.SemiBold
+            } else {
+                FontWeight.Normal
+            },
         )
+        if (!info.destHost.isNullOrBlank()) {
+            Text(
+                "IP ${info.destIp}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (threatLabel != null) {
+            Text(
+                threatLabel,
+                style = MaterialTheme.typography.labelMedium,
+                color = destColor,
+            )
+        }
         Text(
             "No timeout — this stays queued until you choose.",
             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
@@ -47,15 +47,28 @@ internal class FirewallPromptNotifier(
 
     fun show(info: FirewallConnectionInfo) {
         ensureChannel()
-        // Notification text cannot reliably use coloured spans across OEMs —
-        // prefix the destination with a threat emoji instead.
-        val dest = threatEmoji(info.threatCategory) + " " + info.displayDestination()
-        val content = appContext.getString(
+        // Notification body text cannot reliably use coloured spans across OEMs.
+        // Prefix only known threats (unknown stays unmarked — never imply "safe").
+        val emoji = info.threatCategory.notificationEmojiOrNull()
+        val dest = if (emoji != null) {
+            "$emoji ${info.displayDestination()}"
+        } else {
+            info.displayDestination()
+        }
+        val base = appContext.getString(
             R.string.firewall_prompt_notif_text,
             info.protocolLabel,
             dest,
             info.destPort,
         )
+        val threatSuffix = when (info.threatCategory) {
+            DomainThreatCategory.MALWARE ->
+                " · " + appContext.getString(R.string.firewall_threat_malware)
+            DomainThreatCategory.TRACKING ->
+                " · " + appContext.getString(R.string.firewall_threat_tracking)
+            DomainThreatCategory.NONE -> ""
+        }
+        val content = base + threatSuffix
         val openPending = detailPendingIntent(info.requestId)
         val allowPending = actionPendingIntent(
             FirewallPromptActionReceiver.ACTION_ALLOW,
@@ -174,11 +187,5 @@ internal class FirewallPromptNotifier(
         private const val REQUEST_OPEN = 4301
         private const val REQUEST_ALLOW = 4302
         private const val REQUEST_DENY = 4303
-
-        fun threatEmoji(category: DomainThreatCategory): String = when (category) {
-            DomainThreatCategory.NONE -> "🟢"
-            DomainThreatCategory.TRACKING -> "🟠"
-            DomainThreatCategory.MALWARE -> "🔴"
-        }
     }
 }

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
@@ -46,10 +46,11 @@ internal class FirewallPromptNotifier(
 
     fun show(info: FirewallConnectionInfo) {
         ensureChannel()
+        val dest = info.displayDestination()
         val content = appContext.getString(
             R.string.firewall_prompt_notif_text,
             info.protocolLabel,
-            info.destIp,
+            dest,
             info.destPort,
         )
         val openPending = detailPendingIntent(info.requestId)

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
@@ -47,7 +47,9 @@ internal class FirewallPromptNotifier(
 
     fun show(info: FirewallConnectionInfo) {
         ensureChannel()
-        val dest = info.displayDestination()
+        // Notification text cannot reliably use coloured spans across OEMs —
+        // prefix the destination with a threat emoji instead.
+        val dest = threatEmoji(info.threatCategory) + " " + info.displayDestination()
         val content = appContext.getString(
             R.string.firewall_prompt_notif_text,
             info.protocolLabel,
@@ -172,5 +174,11 @@ internal class FirewallPromptNotifier(
         private const val REQUEST_OPEN = 4301
         private const val REQUEST_ALLOW = 4302
         private const val REQUEST_DENY = 4303
+
+        fun threatEmoji(category: DomainThreatCategory): String = when (category) {
+            DomainThreatCategory.NONE -> "🟢"
+            DomainThreatCategory.TRACKING -> "🟠"
+            DomainThreatCategory.MALWARE -> "🔴"
+        }
     }
 }

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
@@ -16,6 +16,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.IconCompat
 import ltechnologies.onionphone.onionvpn.R
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
 import ltechnologies.onionphone.onionvpn.core.model.FirewallConnectionInfo
 import timber.log.Timber
 

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallRulesStore.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallRulesStore.kt
@@ -99,6 +99,7 @@ class FirewallRulesStore @Inject constructor(
                     .put("packageName", r.packageName)
                     .put("appLabel", r.appLabel)
                     .put("destHost", r.destHost)
+                    .put("displayHost", r.displayHost)
                     .put("destPort", r.destPort)
                     .put("protocol", r.protocol)
                     .put("verdict", r.verdict.name)
@@ -131,6 +132,7 @@ class FirewallRulesStore @Inject constructor(
                             scope = FirewallRuleScope.valueOf(o.getString("scope")),
                             expiresAtEpochMs = expires,
                             createdAtEpochMs = o.optLong("createdAtEpochMs", 0L),
+                            displayHost = o.optString("displayHost"),
                         ),
                     )
                 }

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallRulesStore.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallRulesStore.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
 import ltechnologies.onionphone.onionvpn.core.model.FirewallJournalEntry
 import ltechnologies.onionphone.onionvpn.core.model.FirewallRule
 import ltechnologies.onionphone.onionvpn.core.model.FirewallRuleScope
@@ -150,6 +151,8 @@ class FirewallRulesStore @Inject constructor(
                     .put("packageName", e.packageName)
                     .put("appLabel", e.appLabel)
                     .put("destIp", e.destIp)
+                    .put("destHost", e.destHost.orEmpty())
+                    .put("threatCategory", e.threatCategory.name)
                     .put("destPort", e.destPort)
                     .put("protocolLabel", e.protocolLabel)
                     .put("verdict", e.verdict.name)
@@ -180,6 +183,10 @@ class FirewallRulesStore @Inject constructor(
                             verdict = FirewallVerdict.valueOf(o.getString("verdict")),
                             scope = FirewallRuleScope.valueOf(o.getString("scope")),
                             note = o.optString("note"),
+                            destHost = o.optString("destHost").takeIf { it.isNotBlank() },
+                            threatCategory = runCatching {
+                                DomainThreatCategory.valueOf(o.optString("threatCategory", "NONE"))
+                            }.getOrDefault(DomainThreatCategory.NONE),
                         ),
                     )
                 }

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/InteractiveFirewallEngine.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/InteractiveFirewallEngine.kt
@@ -294,12 +294,14 @@ class InteractiveFirewallEngine @Inject constructor(
             uid = answered.request.uid,
             packageName = answered.request.packageName,
             appLabel = answered.request.appLabel,
+            // Match key stays the packet IP; hostname is display-only.
             destHost = answered.request.destIp,
             destPort = answered.request.destPort,
             protocol = answered.request.protocol,
             verdict = verdict,
             scope = ruleScope,
             expiresAtEpochMs = expires,
+            displayHost = answered.request.destHost.orEmpty(),
         )
         scope.launch { rulesStore.upsert(rule) }
         rules.updateAndGet { list ->

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/InteractiveFirewallEngine.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/InteractiveFirewallEngine.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
 import ltechnologies.onionphone.onionvpn.core.model.FirewallConnectionInfo
 import ltechnologies.onionphone.onionvpn.core.model.FirewallDefaultAction
 import ltechnologies.onionphone.onionvpn.core.model.FirewallJournalEntry
@@ -27,11 +28,13 @@ import ltechnologies.onionphone.onionvpn.core.model.FirewallRule
 import ltechnologies.onionphone.onionvpn.core.model.FirewallRuleScope
 import ltechnologies.onionphone.onionvpn.core.model.FirewallVerdict
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
+import ltechnologies.onionphone.onionvpn.core.vpn.dns.DnsHostnameCache
 import ltechnologies.onionphone.onionvpn.core.vpn.firewall.ConnectionOwnerResolver
 import ltechnologies.onionphone.onionvpn.core.vpn.firewall.IpPacketInfo
 import ltechnologies.onionphone.onionvpn.core.vpn.firewall.IpPacketParser
 import ltechnologies.onionphone.onionvpn.core.vpn.firewall.PacketFirewall
 import ltechnologies.onionphone.onionvpn.prefs.TunnelPreferencesStore
+import ltechnologies.onionphone.onionvpn.threat.DomainReputationRepository
 import timber.log.Timber
 
 /**
@@ -49,6 +52,7 @@ class InteractiveFirewallEngine @Inject constructor(
     @ApplicationContext private val context: Context,
     private val rulesStore: FirewallRulesStore,
     private val preferencesStore: TunnelPreferencesStore,
+    private val domainReputation: DomainReputationRepository,
 ) : PacketFirewall {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val ownerResolver = ConnectionOwnerResolver(context)
@@ -200,6 +204,8 @@ class InteractiveFirewallEngine @Inject constructor(
         ruleKey: String,
         decisionKey: Long,
     ): Boolean {
+        val destHost = DnsHostnameCache.lookup(info.dstIp)
+        val threat = domainReputation.classify(destHost)
         val request = FirewallConnectionInfo(
             requestId = UUID.randomUUID().toString(),
             uid = uid,
@@ -209,6 +215,8 @@ class InteractiveFirewallEngine @Inject constructor(
             destPort = info.dstPort,
             protocol = info.protocol,
             protocolLabel = IpPacketParser.protocolLabel(info.protocol),
+            destHost = destHost,
+            threatCategory = threat,
         )
         val queued = QueuedPrompt(request, flowKey, app, ruleKey, decisionKey)
         synchronized(queueLock) {
@@ -312,6 +320,8 @@ class InteractiveFirewallEngine @Inject constructor(
             uid = answered.request.uid,
             app = answered.app,
             destIp = answered.request.destIp,
+            destHost = answered.request.destHost,
+            threatCategory = answered.request.threatCategory,
             destPort = answered.request.destPort,
             protocolLabel = answered.request.protocolLabel,
             verdict = verdict,
@@ -407,10 +417,13 @@ class InteractiveFirewallEngine @Inject constructor(
         scope: FirewallRuleScope,
         note: String,
     ) {
+        val destHost = DnsHostnameCache.lookup(info.dstIp)
         appendJournal(
             uid = uid,
             app = app,
             destIp = info.dstIp,
+            destHost = destHost,
+            threatCategory = domainReputation.classify(destHost),
             destPort = info.dstPort,
             protocolLabel = IpPacketParser.protocolLabel(info.protocol),
             verdict = verdict,
@@ -423,6 +436,8 @@ class InteractiveFirewallEngine @Inject constructor(
         uid: Int,
         app: AppIdentity,
         destIp: String,
+        destHost: String?,
+        threatCategory: DomainThreatCategory,
         destPort: Int,
         protocolLabel: String,
         verdict: FirewallVerdict,
@@ -441,6 +456,8 @@ class InteractiveFirewallEngine @Inject constructor(
             verdict = verdict,
             scope = ruleScope,
             note = note,
+            destHost = destHost,
+            threatCategory = threatCategory,
         )
         // Non-blocking: DROP_OLDEST if journal writer is behind (TUN must never wait).
         journalChannel.trySend(entry)

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/ThreatUi.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/ThreatUi.kt
@@ -1,0 +1,35 @@
+package ltechnologies.onionphone.onionvpn.firewall
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import ltechnologies.onionphone.onionvpn.R
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
+
+/** Shared threat colours for Compose firewall surfaces (prompt + journal). */
+object ThreatColors {
+    val Orange = Color(0xFFE65100)
+    val Red = Color(0xFFC62828)
+}
+
+@Composable
+fun threatTextColor(category: DomainThreatCategory): Color = when (category) {
+    DomainThreatCategory.MALWARE -> ThreatColors.Red
+    DomainThreatCategory.TRACKING -> ThreatColors.Orange
+    DomainThreatCategory.NONE -> MaterialTheme.colorScheme.onSurface
+}
+
+@Composable
+fun threatLabelOrNull(category: DomainThreatCategory): String? = when (category) {
+    DomainThreatCategory.MALWARE -> stringResource(R.string.firewall_threat_malware)
+    DomainThreatCategory.TRACKING -> stringResource(R.string.firewall_threat_tracking)
+    DomainThreatCategory.NONE -> null
+}
+
+/** Notification-safe marker — coloured spans are unreliable on Android OEMs. */
+fun DomainThreatCategory.notificationEmojiOrNull(): String? = when (this) {
+    DomainThreatCategory.NONE -> null
+    DomainThreatCategory.TRACKING -> "🟠"
+    DomainThreatCategory.MALWARE -> "🔴"
+}

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/service/TunnelForegroundService.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/service/TunnelForegroundService.kt
@@ -42,6 +42,7 @@ import ltechnologies.onionphone.onionvpn.core.vpn.OnionVpnService
 import ltechnologies.onionphone.onionvpn.core.vpn.net.TorBandwidthSampler
 import ltechnologies.onionphone.onionvpn.firewall.InteractiveFirewallEngine
 import ltechnologies.onionphone.onionvpn.prefs.TunnelPreferencesStore
+import ltechnologies.onionphone.onionvpn.threat.DomainReputationRepository
 import timber.log.Timber
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -61,6 +62,7 @@ class TunnelForegroundService : Service() {
     @Inject lateinit var dnsCrypt: DnsCryptProcessManager
     @Inject lateinit var preferencesStore: TunnelPreferencesStore
     @Inject lateinit var firewallEngine: InteractiveFirewallEngine
+    @Inject lateinit var domainReputation: DomainReputationRepository
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val lifecycleMutex = Mutex()
@@ -243,6 +245,7 @@ class TunnelForegroundService : Service() {
             handleFailure(failure.userMessage, fromValidation = false, stopTorProcesses = failure.stopTor)
             return
         }
+        domainReputation.onTorReady()
 
         updateSnapshot(TunnelPhase.StartingDnsCrypt, torRunning = true)
         val useDnsCrypt = preferences.dnsResolverMode == DnsResolverMode.DNSCRYPT_MUX

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/threat/DomainReputationIndex.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/threat/DomainReputationIndex.kt
@@ -1,0 +1,113 @@
+package ltechnologies.onionphone.onionvpn.threat
+
+import java.io.BufferedReader
+import java.io.File
+import java.io.Reader
+import java.util.concurrent.atomic.AtomicReference
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
+import timber.log.Timber
+
+/**
+ * In-memory domain blocklists with parent-domain matching.
+ *
+ * HaGeZi `*-onlydomains.txt` lists are "domains without subdomains": an entry
+ * `tracker.example` matches `a.b.tracker.example` and `tracker.example`.
+ *
+ * Classification priority: [DomainThreatCategory.MALWARE] over
+ * [DomainThreatCategory.TRACKING].
+ */
+class DomainReputationIndex {
+    private val malware = AtomicReference<Set<String>>(emptySet())
+    private val tracking = AtomicReference<Set<String>>(emptySet())
+
+    fun malwareCount(): Int = malware.get().size
+    fun trackingCount(): Int = tracking.get().size
+
+    fun classify(hostname: String?): DomainThreatCategory {
+        if (hostname.isNullOrBlank()) return DomainThreatCategory.NONE
+        val host = hostname.trim().trimEnd('.').lowercase()
+        if (host.isEmpty() || looksLikeIp(host)) return DomainThreatCategory.NONE
+        if (matches(malware.get(), host)) return DomainThreatCategory.MALWARE
+        if (matches(tracking.get(), host)) return DomainThreatCategory.TRACKING
+        return DomainThreatCategory.NONE
+    }
+
+    fun replaceMalware(domains: Set<String>) {
+        malware.set(domains)
+        Timber.i("Domain reputation malware set loaded: %d entries", domains.size)
+    }
+
+    fun replaceTracking(domains: Set<String>) {
+        tracking.set(domains)
+        Timber.i("Domain reputation tracking set loaded: %d entries", domains.size)
+    }
+
+    fun loadMalwareFrom(file: File): Boolean = loadInto(file, ::replaceMalware)
+
+    fun loadTrackingFrom(file: File): Boolean = loadInto(file, ::replaceTracking)
+
+    private fun loadInto(file: File, setter: (Set<String>) -> Unit): Boolean {
+        if (!file.isFile || file.length() == 0L) return false
+        return try {
+            val set = HashSet<String>((file.length() / 24).toInt().coerceAtLeast(1_024))
+            file.bufferedReader(Charsets.UTF_8).use { parseDomains(it, set) }
+            setter(set)
+            true
+        } catch (error: Exception) {
+            Timber.w(error, "Failed to load domain list %s", file.name)
+            false
+        }
+    }
+
+    companion object {
+        fun parseDomains(reader: Reader, into: MutableSet<String>): Boolean {
+            val br = reader as? BufferedReader ?: BufferedReader(reader)
+            var count = 0
+            br.lineSequence().forEach { raw ->
+                val line = raw.trim()
+                if (line.isEmpty() || line.startsWith("#") || line.startsWith("!")) return@forEach
+                // Accept plain domain, or "0.0.0.0 domain" / "127.0.0.1 domain" hosts lines.
+                val domain = when {
+                    line.startsWith("0.0.0.0 ") || line.startsWith("127.0.0.1 ") ->
+                        line.substringAfter(' ').trim().substringBefore(' ').trim()
+                    line.contains(' ') || line.contains('\t') ->
+                        line.substringAfterLast(' ').trim().ifEmpty {
+                            line.substringAfterLast('\t').trim()
+                        }
+                    else -> line
+                }.trimEnd('.').lowercase()
+                if (domain.isEmpty() || domain == "localhost" || looksLikeIp(domain)) return@forEach
+                if (!domain.any { it == '.' }) return@forEach // skip TLDs-only noise
+                into.add(domain)
+                count++
+            }
+            return count > 0
+        }
+
+        fun matches(set: Set<String>, hostname: String): Boolean {
+            if (set.isEmpty()) return false
+            var h = hostname
+            while (true) {
+                if (set.contains(h)) return true
+                val dot = h.indexOf('.')
+                if (dot < 0) return false
+                h = h.substring(dot + 1)
+                // Need at least one more dot for a registrable-looking suffix, but
+                // lists may include single-label CDN names — still check them.
+                if (h.isEmpty()) return false
+            }
+        }
+
+        fun looksLikeIp(value: String): Boolean {
+            if (value.indexOf(':') >= 0) return true
+            var dots = 0
+            for (ch in value) {
+                when {
+                    ch == '.' -> dots++
+                    ch !in '0'..'9' -> return false
+                }
+            }
+            return dots == 3
+        }
+    }
+}

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/threat/DomainReputationRepository.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/threat/DomainReputationRepository.kt
@@ -1,0 +1,288 @@
+package ltechnologies.onionphone.onionvpn.threat
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
+import ltechnologies.onionphone.onionvpn.core.model.TunnelEndpoints
+import ltechnologies.onionphone.onionvpn.core.tor.TorProcessManager
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import timber.log.Timber
+
+/**
+ * Downloads and refreshes HaGeZi DNS blocklists used to colour firewall prompts:
+ *
+ * - **Malware / C2 (red):** HaGeZi Threat Intelligence Feeds (TIF) mini
+ * - **Ads / tracking / telemetry (orange):** HaGeZi Light + Native Tracker lists
+ *
+ * Prefer Tor probe SOCKS when the tunnel is up; otherwise fall back to direct HTTPS
+ * so lists can be seeded before the first VPN session.
+ *
+ * Sources: https://github.com/hagezi/dns-blocklists
+ */
+@Singleton
+class DomainReputationRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val tor: TorProcessManager,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val index = DomainReputationIndex()
+    private val updateMutex = Mutex()
+    private val started = AtomicBoolean(false)
+
+    private val _status = MutableStateFlow(DomainReputationStatus())
+    val status: StateFlow<DomainReputationStatus> = _status.asStateFlow()
+
+    fun classify(hostname: String?): DomainThreatCategory = index.classify(hostname)
+
+    fun start() {
+        if (!started.compareAndSet(false, true)) return
+        scope.launch {
+            loadCached()
+            maybeAutoUpdate()
+        }
+    }
+
+    /** Force a refresh (Settings button / post-Tor-ready hook). */
+    fun requestUpdate() {
+        scope.launch { update() }
+    }
+
+    /** Called when Tor becomes ready so the next refresh can use probe SOCKS. */
+    fun onTorReady() {
+        scope.launch { maybeAutoUpdate() }
+    }
+
+    private suspend fun maybeAutoUpdate() {
+        val st = _status.value
+        val age = System.currentTimeMillis() - st.lastSuccessEpochMs
+        if (st.lastSuccessEpochMs > 0L && age < REFRESH_INTERVAL_MS) return
+        update()
+    }
+
+    private suspend fun loadCached() = withContext(Dispatchers.IO) {
+        val dir = listDir()
+        val malwareOk = index.loadMalwareFrom(File(dir, MALWARE_FILE))
+        val trackingOk = index.loadTrackingFrom(File(dir, TRACKING_FILE))
+        val meta = File(dir, META_FILE)
+        val lastSuccess = meta.takeIf { it.isFile }?.readText()?.toLongOrNull() ?: 0L
+        _status.value = DomainReputationStatus(
+            malwareEntries = index.malwareCount(),
+            trackingEntries = index.trackingCount(),
+            lastSuccessEpochMs = lastSuccess,
+            lastError = null,
+            updating = false,
+            loadedFromCache = malwareOk || trackingOk,
+        )
+    }
+
+    private suspend fun update() {
+        updateMutex.withLock {
+            if (_status.value.updating) return@withLock
+            _status.value = _status.value.copy(updating = true, lastError = null)
+            val result = runCatching {
+                withContext(Dispatchers.IO) { downloadAndSwap() }
+            }
+            result.onSuccess {
+                val now = System.currentTimeMillis()
+                File(listDir(), META_FILE).writeText(now.toString())
+                _status.value = DomainReputationStatus(
+                    malwareEntries = index.malwareCount(),
+                    trackingEntries = index.trackingCount(),
+                    lastSuccessEpochMs = now,
+                    lastError = null,
+                    updating = false,
+                    loadedFromCache = true,
+                )
+                Timber.i(
+                    "Domain reputation updated malware=%d tracking=%d",
+                    index.malwareCount(),
+                    index.trackingCount(),
+                )
+            }.onFailure { error ->
+                Timber.w(error, "Domain reputation update failed")
+                _status.value = _status.value.copy(
+                    updating = false,
+                    lastError = error.message ?: "update failed",
+                )
+            }
+        }
+    }
+
+    private fun downloadAndSwap() {
+        val dir = listDir()
+        val client = buildClient()
+        try {
+            val malwareTmp = File(dir, "$MALWARE_FILE.tmp")
+            val trackingTmp = File(dir, "$TRACKING_FILE.tmp")
+
+            downloadFirstAvailable(client, MALWARE_URLS, malwareTmp)
+            // Tracking = Light (ads/tracking/metrics) + Native OEM telemetry lists.
+            trackingTmp.bufferedWriter(Charsets.UTF_8).use { out ->
+                out.appendLine("# OnionVPN merged tracking/telemetry list")
+                out.appendLine("# Base: HaGeZi Light + Native Tracker")
+                val light = downloadBodyFirstAvailable(client, TRACKING_LIGHT_URLS)
+                out.appendLine("# source: HaGeZi Light")
+                out.append(light)
+                if (!light.endsWith('\n')) out.appendLine()
+                for (url in TRACKING_NATIVE_URLS) {
+                    try {
+                        val body = fetchBody(client, url)
+                        out.appendLine("# source: $url")
+                        out.append(body)
+                        if (!body.endsWith('\n')) out.appendLine()
+                    } catch (error: Exception) {
+                        Timber.d(error, "Optional native list skipped: %s", url)
+                    }
+                }
+            }
+
+            val malwareSet = HashSet<String>(180_000)
+            malwareTmp.bufferedReader(Charsets.UTF_8).use {
+                DomainReputationIndex.parseDomains(it, malwareSet)
+            }
+            val trackingSet = HashSet<String>(64_000)
+            trackingTmp.bufferedReader(Charsets.UTF_8).use {
+                DomainReputationIndex.parseDomains(it, trackingSet)
+            }
+            if (malwareSet.isEmpty() && trackingSet.isEmpty()) {
+                throw IllegalStateException("Downloaded domain lists were empty")
+            }
+
+            val malwareFinal = File(dir, MALWARE_FILE)
+            val trackingFinal = File(dir, TRACKING_FILE)
+            if (!malwareTmp.renameTo(malwareFinal)) {
+                malwareTmp.copyTo(malwareFinal, overwrite = true)
+                malwareTmp.delete()
+            }
+            if (!trackingTmp.renameTo(trackingFinal)) {
+                trackingTmp.copyTo(trackingFinal, overwrite = true)
+                trackingTmp.delete()
+            }
+
+            if (malwareSet.isNotEmpty()) index.replaceMalware(malwareSet)
+            if (trackingSet.isNotEmpty()) index.replaceTracking(trackingSet)
+        } finally {
+            client.dispatcher.executorService.shutdown()
+            client.connectionPool.evictAll()
+        }
+    }
+
+    private fun downloadFirstAvailable(client: OkHttpClient, urls: List<String>, dest: File) {
+        dest.writeText(downloadBodyFirstAvailable(client, urls), Charsets.UTF_8)
+    }
+
+    private fun downloadBodyFirstAvailable(client: OkHttpClient, urls: List<String>): String {
+        var lastError: Exception? = null
+        for (url in urls) {
+            try {
+                val body = fetchBody(client, url)
+                if (body.isNotBlank()) return body
+            } catch (error: Exception) {
+                lastError = error
+                Timber.d(error, "Blocklist mirror failed: %s", url)
+            }
+        }
+        throw lastError ?: IllegalStateException("No blocklist mirrors configured")
+    }
+
+    private fun fetchBody(client: OkHttpClient, url: String): String {
+        val response = client.newCall(
+            Request.Builder()
+                .url(url)
+                .header("User-Agent", "OnionVPN-DomainReputation/1.0")
+                .header("Accept", "text/plain")
+                .build(),
+        ).execute()
+        return response.use {
+            if (!it.isSuccessful) {
+                throw IllegalStateException("HTTP ${it.code} for $url")
+            }
+            it.body?.string().orEmpty()
+        }
+    }
+
+    private fun buildClient(): OkHttpClient {
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(true)
+        val probePort = tor.currentProbeSocksPort()
+        if (probePort != null && tor.isRunning()) {
+            val proxy = Proxy(
+                Proxy.Type.SOCKS,
+                InetSocketAddress(TunnelEndpoints.LOOPBACK, probePort),
+            )
+            builder.proxy(proxy)
+            Timber.i("Domain reputation download via Tor probe SOCKS :%d", probePort)
+        } else {
+            Timber.i("Domain reputation download via direct HTTPS (Tor not ready)")
+        }
+        return builder.build()
+    }
+
+    private fun listDir(): File =
+        File(context.filesDir, "domain-reputation").also { it.mkdirs() }
+
+    companion object {
+        private const val MALWARE_FILE = "hagezi-tif-mini.txt"
+        private const val TRACKING_FILE = "hagezi-tracking.txt"
+        private const val META_FILE = "last-success.txt"
+        /** HaGeZi lists expire ~12h–1d; refresh daily. */
+        private const val REFRESH_INTERVAL_MS = 24L * 60L * 60L * 1000L
+
+        private val MALWARE_URLS = listOf(
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/tif.mini-onlydomains.txt",
+            "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.mini-onlydomains.txt",
+            "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/tif.mini-onlydomains.txt",
+        )
+
+        private val TRACKING_LIGHT_URLS = listOf(
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/light-onlydomains.txt",
+            "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/light-onlydomains.txt",
+            "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/light-onlydomains.txt",
+        )
+
+        private val TRACKING_NATIVE_URLS = listOf(
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.apple-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.amazon-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.huawei-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.samsung-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.xiaomi-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.oppo-realme-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.vivo-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.winoffice-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.tiktok-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.roku-onlydomains.txt",
+            "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/native.lgwebos-onlydomains.txt",
+        )
+    }
+}
+
+data class DomainReputationStatus(
+    val malwareEntries: Int = 0,
+    val trackingEntries: Int = 0,
+    val lastSuccessEpochMs: Long = 0L,
+    val lastError: String? = null,
+    val updating: Boolean = false,
+    val loadedFromCache: Boolean = false,
+)

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/threat/DomainReputationRepository.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/threat/DomainReputationRepository.kt
@@ -65,9 +65,19 @@ class DomainReputationRepository @Inject constructor(
         scope.launch { update() }
     }
 
-    /** Called when Tor becomes ready so the next refresh can use probe SOCKS. */
+    /**
+     * Prefer a Tor-backed refresh when probe SOCKS appears.
+     * If the last success was clearnet (or never via Tor), refresh immediately.
+     */
     fun onTorReady() {
-        scope.launch { maybeAutoUpdate() }
+        scope.launch {
+            val st = _status.value
+            if (!st.lastViaTor) {
+                update()
+            } else {
+                maybeAutoUpdate()
+            }
+        }
     }
 
     private suspend fun maybeAutoUpdate() {
@@ -83,6 +93,8 @@ class DomainReputationRepository @Inject constructor(
         val trackingOk = index.loadTrackingFrom(File(dir, TRACKING_FILE))
         val meta = File(dir, META_FILE)
         val lastSuccess = meta.takeIf { it.isFile }?.readText()?.toLongOrNull() ?: 0L
+        val lastViaTor = File(dir, VIA_TOR_FILE).takeIf { it.isFile }
+            ?.readText()?.trim() == "1"
         _status.value = DomainReputationStatus(
             malwareEntries = index.malwareCount(),
             trackingEntries = index.trackingCount(),
@@ -90,6 +102,7 @@ class DomainReputationRepository @Inject constructor(
             lastError = null,
             updating = false,
             loadedFromCache = malwareOk || trackingOk,
+            lastViaTor = lastViaTor,
         )
     }
 
@@ -100,9 +113,11 @@ class DomainReputationRepository @Inject constructor(
             val result = runCatching {
                 withContext(Dispatchers.IO) { downloadAndSwap() }
             }
-            result.onSuccess {
+            result.onSuccess { viaTor ->
                 val now = System.currentTimeMillis()
-                File(listDir(), META_FILE).writeText(now.toString())
+                val dir = listDir()
+                File(dir, META_FILE).writeText(now.toString())
+                File(dir, VIA_TOR_FILE).writeText(if (viaTor) "1" else "0")
                 _status.value = DomainReputationStatus(
                     malwareEntries = index.malwareCount(),
                     trackingEntries = index.trackingCount(),
@@ -110,11 +125,13 @@ class DomainReputationRepository @Inject constructor(
                     lastError = null,
                     updating = false,
                     loadedFromCache = true,
+                    lastViaTor = viaTor,
                 )
                 Timber.i(
-                    "Domain reputation updated malware=%d tracking=%d",
+                    "Domain reputation updated malware=%d tracking=%d viaTor=%s",
                     index.malwareCount(),
                     index.trackingCount(),
+                    viaTor,
                 )
             }.onFailure { error ->
                 Timber.w(error, "Domain reputation update failed")
@@ -126,9 +143,11 @@ class DomainReputationRepository @Inject constructor(
         }
     }
 
-    private fun downloadAndSwap() {
+    /** @return true when the download used Tor probe SOCKS. */
+    private fun downloadAndSwap(): Boolean {
         val dir = listDir()
-        val client = buildClient()
+        val transport = buildClient()
+        val client = transport.client
         try {
             val malwareTmp = File(dir, "$MALWARE_FILE.tmp")
             val trackingTmp = File(dir, "$TRACKING_FILE.tmp")
@@ -179,6 +198,7 @@ class DomainReputationRepository @Inject constructor(
 
             if (malwareSet.isNotEmpty()) index.replaceMalware(malwareSet)
             if (trackingSet.isNotEmpty()) index.replaceTracking(trackingSet)
+            return transport.viaTor
         } finally {
             client.dispatcher.executorService.shutdown()
             client.connectionPool.evictAll()
@@ -219,7 +239,9 @@ class DomainReputationRepository @Inject constructor(
         }
     }
 
-    private fun buildClient(): OkHttpClient {
+    private data class HttpTransport(val client: OkHttpClient, val viaTor: Boolean)
+
+    private fun buildClient(): HttpTransport {
         val builder = OkHttpClient.Builder()
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(120, TimeUnit.SECONDS)
@@ -234,10 +256,10 @@ class DomainReputationRepository @Inject constructor(
             )
             builder.proxy(proxy)
             Timber.i("Domain reputation download via Tor probe SOCKS :%d", probePort)
-        } else {
-            Timber.i("Domain reputation download via direct HTTPS (Tor not ready)")
+            return HttpTransport(builder.build(), viaTor = true)
         }
-        return builder.build()
+        Timber.i("Domain reputation download via direct HTTPS (Tor not ready)")
+        return HttpTransport(builder.build(), viaTor = false)
     }
 
     private fun listDir(): File =
@@ -247,6 +269,7 @@ class DomainReputationRepository @Inject constructor(
         private const val MALWARE_FILE = "hagezi-tif-mini.txt"
         private const val TRACKING_FILE = "hagezi-tracking.txt"
         private const val META_FILE = "last-success.txt"
+        private const val VIA_TOR_FILE = "last-via-tor.txt"
         /** HaGeZi lists expire ~12h–1d; refresh daily. */
         private const val REFRESH_INTERVAL_MS = 24L * 60L * 60L * 1000L
 
@@ -285,4 +308,6 @@ data class DomainReputationStatus(
     val lastError: String? = null,
     val updating: Boolean = false,
     val loadedFromCache: Boolean = false,
+    /** True when the last successful download used Tor probe SOCKS. */
+    val lastViaTor: Boolean = false,
 )

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/FirewallScreen.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/FirewallScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
 import ltechnologies.onionphone.onionvpn.core.model.FirewallJournalEntry
 import ltechnologies.onionphone.onionvpn.core.model.FirewallRule
 import ltechnologies.onionphone.onionvpn.core.model.FirewallRuleScope
@@ -27,6 +29,9 @@ import ltechnologies.onionphone.onionvpn.core.model.FirewallVerdict
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
 import ltechnologies.onionphone.onionvpn.firewall.FirewallPromptContent
 import ltechnologies.onionphone.onionvpn.firewall.InteractiveFirewallEngine
+
+private val ThreatOrange = Color(0xFFE65100)
+private val ThreatRed = Color(0xFFC62828)
 
 @Composable
 fun FirewallScreen(
@@ -143,13 +148,20 @@ private fun JournalRow(entry: FirewallJournalEntry) {
             },
         )
         Text(
-            "${entry.protocolLabel} ${entry.destIp}:${entry.destPort}" +
+            "${entry.protocolLabel} ${journalDest(entry)}:${entry.destPort}" +
                 if (entry.note.isNotBlank()) " · ${entry.note}" else "",
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = when (entry.threatCategory) {
+                DomainThreatCategory.MALWARE -> ThreatRed
+                DomainThreatCategory.TRACKING -> ThreatOrange
+                DomainThreatCategory.NONE -> MaterialTheme.colorScheme.onSurfaceVariant
+            },
         )
     }
 }
+
+private fun journalDest(entry: FirewallJournalEntry): String =
+    entry.destHost?.takeIf { it.isNotBlank() } ?: entry.destIp
 
 private fun destLabel(rule: FirewallRule): String {
     val host = rule.destHost.ifEmpty { "*" }

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/FirewallScreen.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/FirewallScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -29,9 +28,8 @@ import ltechnologies.onionphone.onionvpn.core.model.FirewallVerdict
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
 import ltechnologies.onionphone.onionvpn.firewall.FirewallPromptContent
 import ltechnologies.onionphone.onionvpn.firewall.InteractiveFirewallEngine
-
-private val ThreatOrange = Color(0xFFE65100)
-private val ThreatRed = Color(0xFFC62828)
+import ltechnologies.onionphone.onionvpn.firewall.threatLabelOrNull
+import ltechnologies.onionphone.onionvpn.firewall.threatTextColor
 
 @Composable
 fun FirewallScreen(
@@ -116,9 +114,16 @@ private fun RuleRow(rule: FirewallRule, onDelete: () -> Unit) {
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                "${rule.appLabel} → ${destLabel(rule)}",
+                "${rule.appLabel} → ${ruleDisplayDest(rule)}",
                 style = MaterialTheme.typography.bodyMedium,
             )
+            if (rule.displayHost.isNotBlank()) {
+                Text(
+                    "IP ${rule.destHost.ifEmpty { "*" }}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Text(
                 "${verdictLabel(rule.verdict)} · ${scopeLabel(rule)}",
                 style = MaterialTheme.typography.labelSmall,
@@ -137,6 +142,11 @@ private fun RuleRow(rule: FirewallRule, onDelete: () -> Unit) {
 private fun JournalRow(entry: FirewallJournalEntry) {
     val time = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
         .format(Date(entry.timestampEpochMs))
+    val threatLabel = threatLabelOrNull(entry.threatCategory)
+    val destColor = when (entry.threatCategory) {
+        DomainThreatCategory.NONE -> MaterialTheme.colorScheme.onSurfaceVariant
+        else -> threatTextColor(entry.threatCategory)
+    }
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
             "$time  ${verdictLabel(entry.verdict)}  ${entry.appLabel}",
@@ -148,23 +158,37 @@ private fun JournalRow(entry: FirewallJournalEntry) {
             },
         )
         Text(
-            "${entry.protocolLabel} ${journalDest(entry)}:${entry.destPort}" +
-                if (entry.note.isNotBlank()) " · ${entry.note}" else "",
-            style = MaterialTheme.typography.bodySmall,
-            color = when (entry.threatCategory) {
-                DomainThreatCategory.MALWARE -> ThreatRed
-                DomainThreatCategory.TRACKING -> ThreatOrange
-                DomainThreatCategory.NONE -> MaterialTheme.colorScheme.onSurfaceVariant
+            buildString {
+                append(entry.protocolLabel)
+                append(' ')
+                append(entry.displayDestination())
+                append(':')
+                append(entry.destPort)
+                if (threatLabel != null) {
+                    append(" · ")
+                    append(threatLabel)
+                }
+                if (entry.note.isNotBlank()) {
+                    append(" · ")
+                    append(entry.note)
+                }
             },
+            style = MaterialTheme.typography.bodySmall,
+            color = destColor,
         )
+        if (!entry.destHost.isNullOrBlank()) {
+            Text(
+                "IP ${entry.destIp}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 
-private fun journalDest(entry: FirewallJournalEntry): String =
-    entry.destHost?.takeIf { it.isNotBlank() } ?: entry.destIp
-
-private fun destLabel(rule: FirewallRule): String {
-    val host = rule.destHost.ifEmpty { "*" }
+/** Hostname primary when known; match key (IP) otherwise — same pattern as prompts. */
+private fun ruleDisplayDest(rule: FirewallRule): String {
+    val host = rule.displayHost.ifBlank { rule.destHost.ifEmpty { "*" } }
     val port = if (rule.destPort < 0) "*" else rule.destPort.toString()
     return "$host:$port"
 }

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/SettingsScreen.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/SettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -40,6 +41,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference
+import ltechnologies.onionphone.onionvpn.R
 import ltechnologies.onionphone.onionvpn.core.dnscrypt.config.DnsCryptPublicResolvers
 import ltechnologies.onionphone.onionvpn.core.model.DnsResolverMode
 import ltechnologies.onionphone.onionvpn.core.model.FirewallDefaultAction
@@ -276,11 +278,9 @@ fun SettingsScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        Text("Domain threat lists", style = MaterialTheme.typography.titleMedium)
+        Text(stringResource(R.string.domain_lists_title), style = MaterialTheme.typography.titleMedium)
         Text(
-            text = "HaGeZi lists colour firewall prompts: orange = ads/tracking/telemetry " +
-                "(Light + Native Tracker), red = malware/C2 (TIF mini). " +
-                "Updates prefer Tor when the tunnel is up.",
+            text = stringResource(R.string.domain_lists_desc),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -289,17 +289,27 @@ fun SettingsScreen(
             SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
                 .format(Date(reputation.lastSuccessEpochMs))
         } else {
-            "never"
+            stringResource(R.string.domain_lists_never)
+        }
+        val transport = when {
+            reputation.lastSuccessEpochMs <= 0L -> ""
+            reputation.lastViaTor -> stringResource(R.string.domain_lists_via_tor)
+            else -> stringResource(R.string.domain_lists_via_direct)
         }
         Text(
-            text = "Tracking: ${reputation.trackingEntries} · Malware: ${reputation.malwareEntries} · " +
-                "Last update: $lastUpdate",
+            text = stringResource(
+                R.string.domain_lists_status,
+                reputation.trackingEntries,
+                reputation.malwareEntries,
+                lastUpdate,
+                transport,
+            ),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         if (reputation.lastError != null) {
             Text(
-                text = "Last error: ${reputation.lastError}",
+                text = stringResource(R.string.domain_lists_last_error, reputation.lastError!!),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.error,
             )
@@ -309,7 +319,13 @@ fun SettingsScreen(
             enabled = !reputation.updating,
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Text(if (reputation.updating) "Updating…" else "Update domain lists")
+            Text(
+                if (reputation.updating) {
+                    stringResource(R.string.domain_lists_updating)
+                } else {
+                    stringResource(R.string.domain_lists_update)
+                },
+            )
         }
 
         Text("Tor", style = MaterialTheme.typography.titleMedium)

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/SettingsScreen.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/SettingsScreen.kt
@@ -35,16 +35,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference
 import ltechnologies.onionphone.onionvpn.core.dnscrypt.config.DnsCryptPublicResolvers
 import ltechnologies.onionphone.onionvpn.core.model.DnsResolverMode
 import ltechnologies.onionphone.onionvpn.core.model.FirewallDefaultAction
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
+import ltechnologies.onionphone.onionvpn.threat.DomainReputationRepository
 import ltechnologies.onionphone.onionvpn.util.SystemSecurityIntents
 
 @Composable
 fun SettingsScreen(
     preferences: TunnelPreferences,
+    domainReputation: DomainReputationRepository,
     onLoadTorrc: () -> String,
     onLoadDnsCryptToml: () -> String,
     onSavePreferences: (TunnelPreferences, restartIfConnected: Boolean) -> Unit,
@@ -269,6 +275,42 @@ fun SettingsScreen(
             enabled = local.firewallEnabled,
             modifier = Modifier.fillMaxWidth(),
         )
+
+        Text("Domain threat lists", style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = "HaGeZi lists colour firewall prompts: orange = ads/tracking/telemetry " +
+                "(Light + Native Tracker), red = malware/C2 (TIF mini). " +
+                "Updates prefer Tor when the tunnel is up.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        val reputation by domainReputation.status.collectAsStateWithLifecycle()
+        val lastUpdate = if (reputation.lastSuccessEpochMs > 0L) {
+            SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+                .format(Date(reputation.lastSuccessEpochMs))
+        } else {
+            "never"
+        }
+        Text(
+            text = "Tracking: ${reputation.trackingEntries} · Malware: ${reputation.malwareEntries} · " +
+                "Last update: $lastUpdate",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (reputation.lastError != null) {
+            Text(
+                text = "Last error: ${reputation.lastError}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+        Button(
+            onClick = { domainReputation.requestUpdate() },
+            enabled = !reputation.updating,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(if (reputation.updating) "Updating…" else "Update domain lists")
+        }
 
         Text("Tor", style = MaterialTheme.typography.titleMedium)
         Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,8 +16,14 @@
     <string name="firewall_threat_malware">Malware / C2</string>
     <string name="firewall_threat_tracking">Ads / tracking / telemetry</string>
     <string name="domain_lists_title">Domain threat lists</string>
+    <string name="domain_lists_desc">HaGeZi lists colour firewall prompts: orange = ads/tracking/telemetry (Light + Native Tracker), red = malware/C2 (TIF mini). Updates prefer Tor when the tunnel is up.</string>
     <string name="domain_lists_update">Update domain lists</string>
     <string name="domain_lists_updating">Updating…</string>
+    <string name="domain_lists_status">Tracking: %1$d · Malware: %2$d · Last update: %3$s%4$s</string>
+    <string name="domain_lists_via_tor"> · via Tor</string>
+    <string name="domain_lists_via_direct"> · direct</string>
+    <string name="domain_lists_never">never</string>
+    <string name="domain_lists_last_error">Last error: %1$s</string>
     <string name="firewall_action_allow">Accept</string>
     <string name="firewall_action_deny">Deny</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,11 @@
     <string name="firewall_prompt_channel_desc">Connection allow/deny requests with Accept and Deny actions</string>
     <string name="firewall_prompt_notif_title">%1$s wants to connect</string>
     <string name="firewall_prompt_notif_text">%1$s → %2$s:%3$d</string>
+    <string name="firewall_threat_malware">Malware / C2</string>
+    <string name="firewall_threat_tracking">Ads / tracking / telemetry</string>
+    <string name="domain_lists_title">Domain threat lists</string>
+    <string name="domain_lists_update">Update domain lists</string>
+    <string name="domain_lists_updating">Updating…</string>
     <string name="firewall_action_allow">Accept</string>
     <string name="firewall_action_deny">Deny</string>
 </resources>

--- a/app/src/test/java/ltechnologies/onionphone/onionvpn/threat/DomainReputationIndexTest.kt
+++ b/app/src/test/java/ltechnologies/onionphone/onionvpn/threat/DomainReputationIndexTest.kt
@@ -1,0 +1,47 @@
+package ltechnologies.onionphone.onionvpn.threat
+
+import java.io.StringReader
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DomainReputationIndexTest {
+    @Test
+    fun parentDomainMatching() {
+        val set = hashSetOf("doubleclick.net", "metrics.apple.com")
+        assertTrue(DomainReputationIndex.matches(set, "ad.doubleclick.net"))
+        assertTrue(DomainReputationIndex.matches(set, "doubleclick.net"))
+        assertTrue(DomainReputationIndex.matches(set, "a.b.metrics.apple.com"))
+        assertFalse(DomainReputationIndex.matches(set, "example.com"))
+        assertFalse(DomainReputationIndex.matches(set, "notdoubleclick.net"))
+    }
+
+    @Test
+    fun malwareTakesPriorityOverTracking() {
+        val index = DomainReputationIndex()
+        index.replaceMalware(setOf("evil.example"))
+        index.replaceTracking(setOf("evil.example", "ads.cdn.test"))
+        assertEquals(DomainThreatCategory.MALWARE, index.classify("c2.evil.example"))
+        assertEquals(DomainThreatCategory.TRACKING, index.classify("x.ads.cdn.test"))
+        assertEquals(DomainThreatCategory.NONE, index.classify("safe.example"))
+        assertEquals(DomainThreatCategory.NONE, index.classify("1.2.3.4"))
+    }
+
+    @Test
+    fun parsePlainAndHostsLines() {
+        val text = """
+            # comment
+            ! also comment
+            doubleclick.net
+            0.0.0.0 ads.tracker.test
+            127.0.0.1 telemetry.oem.test
+        """.trimIndent()
+        val into = HashSet<String>()
+        assertTrue(DomainReputationIndex.parseDomains(StringReader(text), into))
+        assertTrue(into.contains("doubleclick.net"))
+        assertTrue(into.contains("ads.tracker.test"))
+        assertTrue(into.contains("telemetry.oem.test"))
+    }
+}

--- a/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/FirewallModels.kt
+++ b/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/FirewallModels.kt
@@ -72,6 +72,19 @@ data class FirewallRule(
     }
 }
 
+/**
+ * Reputation of a destination hostname from local blocklist databases.
+ *
+ * - [TRACKING]: ads / tracking / telemetry → orange in the UI
+ * - [MALWARE]: malware / C2 / phishing → red in the UI
+ * - [NONE]: unknown or not listed
+ */
+enum class DomainThreatCategory {
+    NONE,
+    TRACKING,
+    MALWARE,
+}
+
 data class FirewallConnectionInfo(
     val requestId: String,
     val uid: Int,
@@ -81,8 +94,14 @@ data class FirewallConnectionInfo(
     val destPort: Int,
     val protocol: Int,
     val protocolLabel: String,
+    /** Resolved hostname from DNS snooping, when available. */
+    val destHost: String? = null,
+    val threatCategory: DomainThreatCategory = DomainThreatCategory.NONE,
     val timestampEpochMs: Long = System.currentTimeMillis(),
-)
+) {
+    /** Prefer hostname for display; fall back to IP. */
+    fun displayDestination(): String = destHost?.takeIf { it.isNotBlank() } ?: destIp
+}
 
 data class FirewallJournalEntry(
     val id: String,
@@ -96,4 +115,6 @@ data class FirewallJournalEntry(
     val verdict: FirewallVerdict,
     val scope: FirewallRuleScope,
     val note: String = "",
+    val destHost: String? = null,
+    val threatCategory: DomainThreatCategory = DomainThreatCategory.NONE,
 )

--- a/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/FirewallModels.kt
+++ b/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/FirewallModels.kt
@@ -35,7 +35,10 @@ data class FirewallRule(
     val uid: Int,
     val packageName: String,
     val appLabel: String,
-    /** Empty = any destination host/IP. */
+    /**
+     * Match key: destination IP (packet path) or empty = any destination.
+     * Hostname is stored separately in [displayHost] for UI only.
+     */
     val destHost: String = "",
     /** -1 = any port. */
     val destPort: Int = -1,
@@ -45,6 +48,8 @@ data class FirewallRule(
     val scope: FirewallRuleScope,
     val expiresAtEpochMs: Long? = null,
     val createdAtEpochMs: Long = System.currentTimeMillis(),
+    /** DNS hostname at decision time (display only; matching uses [destHost]/IP). */
+    val displayHost: String = "",
 ) {
     fun isExpired(nowMs: Long = System.currentTimeMillis()): Boolean {
         if (scope == FirewallRuleScope.TEMPORARY) {
@@ -117,4 +122,7 @@ data class FirewallJournalEntry(
     val note: String = "",
     val destHost: String? = null,
     val threatCategory: DomainThreatCategory = DomainThreatCategory.NONE,
-)
+) {
+    /** Prefer hostname for display; fall back to IP. */
+    fun displayDestination(): String = destHost?.takeIf { it.isNotBlank() } ?: destIp
+}

--- a/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/TorProcessManager.kt
+++ b/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/TorProcessManager.kt
@@ -128,6 +128,10 @@ class TorProcessManager(
 
     fun isRunning(): Boolean = process?.isAlive == true
 
+    /** Probe SocksPort while Tor is up; used for reputation list downloads. */
+    fun currentProbeSocksPort(): Int? =
+        runtimePorts?.torProbeSocksPort?.takeIf { isRunning() }
+
     /** SIGNAL NEWNYM + CLEARDNSCACHE (user “new identity”). */
     fun newNym(): Result<Unit> {
         if (!control.isConnected) return Result.failure(IOException("control not connected"))

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/dns/DnsHostnameCache.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/dns/DnsHostnameCache.kt
@@ -1,0 +1,61 @@
+package ltechnologies.onionphone.onionvpn.core.vpn.dns
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * IP → hostname map filled by DNS snooping in [ltechnologies.onionphone.onionvpn.core.vpn.forwarder.TunDnsMux].
+ *
+ * Lookups are lock-free reads for the firewall ASK path. Entries are trimmed FIFO-ish when
+ * [MAX_ENTRIES] is exceeded (budgeted key removal — never blocks TUN).
+ */
+object DnsHostnameCache {
+    private val ipToHost = ConcurrentHashMap<String, String>(512)
+    private val sizeApprox = AtomicInteger(0)
+
+    fun put(ip: String, hostname: String) {
+        val host = hostname.trim().trimEnd('.').lowercase()
+        if (ip.isBlank() || host.isBlank() || host == "localhost") return
+        if (looksLikeIp(host)) return
+        val previous = ipToHost.put(ip, host)
+        if (previous == null) {
+            val n = sizeApprox.incrementAndGet()
+            if (n > MAX_ENTRIES) trim()
+        }
+    }
+
+    fun lookup(ip: String): String? = ipToHost[ip]
+
+    fun clear() {
+        ipToHost.clear()
+        sizeApprox.set(0)
+    }
+
+    fun size(): Int = ipToHost.size
+
+    private fun trim() {
+        var n = 0
+        val it = ipToHost.keys.iterator()
+        while (it.hasNext() && n < TRIM_BUDGET) {
+            it.next()
+            it.remove()
+            sizeApprox.decrementAndGet()
+            n++
+        }
+    }
+
+    private fun looksLikeIp(value: String): Boolean {
+        if (value.indexOf(':') >= 0) return true // IPv6
+        var dots = 0
+        for (ch in value) {
+            when {
+                ch == '.' -> dots++
+                ch !in '0'..'9' -> return false
+            }
+        }
+        return dots == 3
+    }
+
+    private const val MAX_ENTRIES = 4_096
+    private const val TRIM_BUDGET = 256
+}

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/dns/DnsPacketParser.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/dns/DnsPacketParser.kt
@@ -1,0 +1,113 @@
+package ltechnologies.onionphone.onionvpn.core.vpn.dns
+
+/**
+ * Minimal DNS message parser for firewall hostname attribution.
+ *
+ * Extracts the first question QNAME and A (type 1) answer RDATA IPv4 addresses.
+ * Does not allocate during failure paths beyond the returned lists.
+ */
+object DnsPacketParser {
+    data class ParsedDns(
+        val queryId: Int,
+        val isResponse: Boolean,
+        val qname: String?,
+        val aRecords: List<String>,
+    )
+
+    fun parse(dns: ByteArray, offset: Int, length: Int): ParsedDns? {
+        if (length < 12 || offset < 0 || offset + length > dns.size) return null
+        val id = ((dns[offset].toInt() and 0xff) shl 8) or (dns[offset + 1].toInt() and 0xff)
+        val flags = ((dns[offset + 2].toInt() and 0xff) shl 8) or (dns[offset + 3].toInt() and 0xff)
+        val isResponse = (flags and 0x8000) != 0
+        val qdCount = ((dns[offset + 4].toInt() and 0xff) shl 8) or (dns[offset + 5].toInt() and 0xff)
+        val anCount = ((dns[offset + 6].toInt() and 0xff) shl 8) or (dns[offset + 7].toInt() and 0xff)
+        var pos = offset + 12
+        val end = offset + length
+
+        var qname: String? = null
+        if (qdCount > 0) {
+            val name = readName(dns, offset, pos, end) ?: return ParsedDns(id, isResponse, null, emptyList())
+            qname = name.first
+            pos = name.second
+            // QTYPE + QCLASS
+            if (pos + 4 > end) return ParsedDns(id, isResponse, qname, emptyList())
+            pos += 4
+            // Skip remaining questions
+            for (i in 1 until qdCount) {
+                val skip = readName(dns, offset, pos, end) ?: break
+                pos = skip.second + 4
+                if (pos > end) break
+            }
+        }
+
+        val answers = ArrayList<String>(minOf(anCount, 8))
+        if (isResponse && anCount > 0 && qname != null) {
+            for (i in 0 until anCount) {
+                if (pos >= end) break
+                val nameSkip = readName(dns, offset, pos, end) ?: break
+                pos = nameSkip.second
+                if (pos + 10 > end) break
+                val type = ((dns[pos].toInt() and 0xff) shl 8) or (dns[pos + 1].toInt() and 0xff)
+                // class at pos+2, ttl at pos+4
+                val rdLength = ((dns[pos + 8].toInt() and 0xff) shl 8) or (dns[pos + 9].toInt() and 0xff)
+                pos += 10
+                if (pos + rdLength > end) break
+                if (type == TYPE_A && rdLength == 4) {
+                    answers.add(
+                        "${dns[pos].toInt() and 0xff}." +
+                            "${dns[pos + 1].toInt() and 0xff}." +
+                            "${dns[pos + 2].toInt() and 0xff}." +
+                            "${dns[pos + 3].toInt() and 0xff}",
+                    )
+                }
+                pos += rdLength
+            }
+        }
+        return ParsedDns(id, isResponse, qname, answers)
+    }
+
+    /**
+     * @return Pair(name, nextOffset) or null on truncation / bad compression
+     */
+    private fun readName(
+        dns: ByteArray,
+        msgOffset: Int,
+        start: Int,
+        end: Int,
+    ): Pair<String, Int>? {
+        val labels = ArrayList<String>(6)
+        var pos = start
+        var jumped = false
+        var next = start
+        var jumps = 0
+        while (pos < end) {
+            val len = dns[pos].toInt() and 0xff
+            when {
+                len == 0 -> {
+                    if (!jumped) next = pos + 1
+                    break
+                }
+                (len and 0xc0) == 0xc0 -> {
+                    if (pos + 1 >= end) return null
+                    val ptr = ((len and 0x3f) shl 8) or (dns[pos + 1].toInt() and 0xff)
+                    if (!jumped) next = pos + 2
+                    pos = msgOffset + ptr
+                    jumped = true
+                    if (++jumps > 16) return null
+                    if (pos < msgOffset || pos >= end) return null
+                    continue
+                }
+                else -> {
+                    if (pos + 1 + len > end) return null
+                    labels.add(String(dns, pos + 1, len, Charsets.US_ASCII))
+                    pos += 1 + len
+                    if (!jumped) next = pos
+                }
+            }
+        }
+        if (labels.isEmpty()) return "" to next
+        return labels.joinToString(".") to next
+    }
+
+    private const val TYPE_A = 1
+}

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/TunDnsMux.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/TunDnsMux.kt
@@ -176,6 +176,9 @@ class TunDnsMux(
         tunToHev = null
         hevToTun = null
         packetPool.clear()
+        // FakeDNS IPs are reused across sessions — drop stale IP→host bindings.
+        pendingQnames.clear()
+        DnsHostnameCache.clear()
         runCatching {
             if (!dnsExecutor.awaitTermination(2, TimeUnit.SECONDS)) {
                 Timber.w("DNS executor did not terminate cleanly")

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/TunDnsMux.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/TunDnsMux.kt
@@ -11,6 +11,8 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
+import ltechnologies.onionphone.onionvpn.core.vpn.dns.DnsHostnameCache
+import ltechnologies.onionphone.onionvpn.core.vpn.dns.DnsPacketParser
 import ltechnologies.onionphone.onionvpn.core.vpn.firewall.FirewallBridge
 import timber.log.Timber
 
@@ -82,6 +84,7 @@ class TunDnsMux(
                             continue
                         }
                         divertDnsToDnsCrypt && isDnsQueryToVpnDns(buf, n, vpnDns) -> {
+                            snoopDnsOutbound(buf, n)
                             val packet = borrowPacket(buf, n)
                             dnsExecutor.execute {
                                 try {
@@ -92,6 +95,8 @@ class TunDnsMux(
                             }
                         }
                         isDnsQueryToVpnDns(buf, n, vpnDns) -> {
+                            // FakeDNS path — still learn QNAME before hev mapdns.
+                            snoopDnsOutbound(buf, n)
                             writeHev(localHevOut, buf, n)
                         }
                         !FirewallBridge.engine.allowOutbound(buf, n) -> {
@@ -125,9 +130,13 @@ class TunDnsMux(
                             LockSupport.parkNanos(EMPTY_READ_PARK_NS)
                             continue
                         }
-                        else -> synchronized(tunWriteLock) {
-                            if (!running.get()) return@synchronized
-                            localTunOut.write(buf, 0, n)
+                        else -> {
+                            // FakeDNS / hev replies: attribute Fake-IP → hostname.
+                            snoopDnsInbound(buf, n)
+                            synchronized(tunWriteLock) {
+                                if (!running.get()) return@synchronized
+                                localTunOut.write(buf, 0, n)
+                            }
                         }
                     }
                 }
@@ -207,6 +216,73 @@ class TunDnsMux(
         return destPort == 53
     }
 
+    /** Learn QNAME from outbound DNS queries (DNSCrypt divert or FakeDNS). */
+    private fun snoopDnsOutbound(packet: ByteArray, length: Int) {
+        val payload = udpDnsPayload(packet, length, expectDestPort53 = true) ?: return
+        val parsed = DnsPacketParser.parse(packet, payload.first, payload.second) ?: return
+        val qname = parsed.qname ?: return
+        // Pending map by query id helps FakeDNS responses that omit useful ANSWER names.
+        if (!parsed.isResponse && parsed.queryId >= 0) {
+            pendingQnames[parsed.queryId] = qname
+            if (pendingQnames.size > PENDING_QNAME_CAP) {
+                val it = pendingQnames.keys.iterator()
+                var n = 0
+                while (it.hasNext() && n < 64) {
+                    it.next()
+                    it.remove()
+                    n++
+                }
+            }
+        }
+    }
+
+    /** Learn IP→host from inbound DNS replies (hev FakeDNS → TUN). */
+    private fun snoopDnsInbound(packet: ByteArray, length: Int) {
+        val payload = udpDnsPayload(packet, length, expectDestPort53 = false) ?: return
+        // Source port 53 = DNS response toward the client.
+        val ihl = (packet[0].toInt() and 0x0f) * 4
+        val srcPort = ((packet[ihl].toInt() and 0xff) shl 8) or (packet[ihl + 1].toInt() and 0xff)
+        if (srcPort != 53) return
+        learnFromDnsPayload(packet, payload.first, payload.second)
+    }
+
+    private fun learnFromDnsPayload(buf: ByteArray, offset: Int, length: Int) {
+        val parsed = DnsPacketParser.parse(buf, offset, length) ?: return
+        if (!parsed.isResponse) return
+        val host = parsed.qname
+            ?: pendingQnames.remove(parsed.queryId)
+            ?: return
+        pendingQnames.remove(parsed.queryId)
+        for (ip in parsed.aRecords) {
+            DnsHostnameCache.put(ip, host)
+        }
+    }
+
+    /**
+     * @return Pair(dnsOffset, dnsLength) for UDP/53 payloads, or null.
+     * @param expectDestPort53 true for client→resolver, false to skip dest-port check.
+     */
+    private fun udpDnsPayload(
+        packet: ByteArray,
+        length: Int,
+        expectDestPort53: Boolean,
+    ): Pair<Int, Int>? {
+        if (length < 28) return null
+        val version = (packet[0].toInt() ushr 4) and 0x0f
+        if (version != 4) return null
+        val ihl = (packet[0].toInt() and 0x0f) * 4
+        if (length < ihl + 8) return null
+        if (packet[9].toInt() and 0xff != PROTO_UDP) return null
+        if (expectDestPort53) {
+            val destPort = ((packet[ihl + 2].toInt() and 0xff) shl 8) or (packet[ihl + 3].toInt() and 0xff)
+            if (destPort != 53) return null
+        }
+        val dnsOffset = ihl + 8
+        val dnsLen = length - dnsOffset
+        if (dnsLen < 12) return null
+        return dnsOffset to dnsLen
+    }
+
     private fun handleDnsQuery(packet: ByteArray, length: Int, tunOut: FileOutputStream) {
         if (!running.get()) return
         try {
@@ -228,6 +304,9 @@ class TunDnsMux(
             )
             val response = DatagramPacket(scratch.responseBuf, scratch.responseBuf.size)
             socket.receive(response)
+
+            // Attribute resolved A records → QNAME for firewall prompts.
+            learnFromDnsPayload(scratch.responseBuf, 0, response.length)
 
             val replyLen = buildDnsReplyInto(
                 request = packet,
@@ -333,7 +412,12 @@ class TunDnsMux(
             Runtime.getRuntime().availableProcessors().coerceIn(2, 4)
         private val DNS_MAX_THREADS = (DNS_CORE_THREADS + 2).coerceAtMost(6)
         private const val DNS_QUEUE_CAP = 64
+        private const val PENDING_QNAME_CAP = 512
 
         private val dnsScratch = ThreadLocal.withInitial { DnsScratch() }
+
+        /** queryId → QNAME for FakeDNS responses that rely on query correlation. */
+        private val pendingQnames =
+            java.util.concurrent.ConcurrentHashMap<Int, String>(64)
     }
 }

--- a/core/vpn/src/test/java/ltechnologies/onionphone/onionvpn/core/vpn/dns/DnsPacketParserTest.kt
+++ b/core/vpn/src/test/java/ltechnologies/onionphone/onionvpn/core/vpn/dns/DnsPacketParserTest.kt
@@ -1,0 +1,77 @@
+package ltechnologies.onionphone.onionvpn.core.vpn.dns
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DnsPacketParserTest {
+    @Test
+    fun parseQueryQname() {
+        // DNS query for www.example.com type A
+        val dns = buildDnsQuery("www.example.com")
+        val parsed = DnsPacketParser.parse(dns, 0, dns.size)
+        assertNotNull(parsed)
+        assertEquals("www.example.com", parsed!!.qname)
+        assertFalse(parsed.isResponse)
+        assertTrue(parsed.aRecords.isEmpty())
+    }
+
+    @Test
+    fun parseResponseARecords() {
+        val qname = "ads.tracker.test"
+        val query = buildDnsQuery(qname)
+        val response = buildDnsResponse(query, listOf(0x0A, 0x14, 0x00, 0x01)) // 10.20.0.1
+        val parsed = DnsPacketParser.parse(response, 0, response.size)
+        assertNotNull(parsed)
+        assertTrue(parsed!!.isResponse)
+        assertEquals(qname, parsed.qname)
+        assertEquals(listOf("10.20.0.1"), parsed.aRecords)
+    }
+
+    private fun buildDnsQuery(name: String): ByteArray {
+        val labels = name.split('.')
+        val nameBytes = labels.sumOf { 1 + it.length } + 1
+        val buf = ByteArray(12 + nameBytes + 4)
+        buf[0] = 0x12
+        buf[1] = 0x34 // id
+        buf[2] = 0x01 // RD
+        buf[5] = 0x01 // qdcount = 1
+        var pos = 12
+        for (label in labels) {
+            buf[pos++] = label.length.toByte()
+            for (ch in label) buf[pos++] = ch.code.toByte()
+        }
+        buf[pos++] = 0
+        buf[pos++] = 0
+        buf[pos++] = 1 // A
+        buf[pos++] = 0
+        buf[pos] = 1 // IN
+        return buf
+    }
+
+    private fun buildDnsResponse(query: ByteArray, ipv4: List<Int>): ByteArray {
+        val out = ByteArray(query.size + 16)
+        System.arraycopy(query, 0, out, 0, query.size)
+        out[2] = (0x80 or 0x01).toByte() // QR + RD
+        out[3] = 0x80.toByte() // RA
+        out[7] = 1 // ancount
+        var pos = query.size
+        // name pointer to offset 12
+        out[pos++] = 0xc0.toByte()
+        out[pos++] = 0x0c
+        out[pos++] = 0
+        out[pos++] = 1 // A
+        out[pos++] = 0
+        out[pos++] = 1 // IN
+        out[pos++] = 0
+        out[pos++] = 0
+        out[pos++] = 0
+        out[pos++] = 60 // TTL
+        out[pos++] = 0
+        out[pos++] = 4 // rdlength
+        for (b in ipv4) out[pos++] = b.toByte()
+        return out
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Les requêtes de permission de connexion affichent le **nom de domaine** (DNS snooping) avec classification HaGeZi :

- **Orange / 🟠** — ads / tracking / télémétrie (Light + Native Tracker)
- **Rouge / 🔴** — malware / C2 (TIF mini)
- **Neutre** — inconnu (pas de faux “safe” vert)

## Surfaces alignées

| Surface | Domaine | Couleur / marqueur | Label menace | IP secondaire |
|---------|---------|--------------------|--------------|---------------|
| Prompt Compose | oui | texte orange/rouge | strings.xml | oui |
| Notification | oui | 🟠/🔴 seulement si menace | suffixe label | — |
| Journal | oui | couleur texte | label | oui |
| Active rules | `displayHost` | — | — | IP (clé de match) |
| Settings | listes HaGeZi | — | statut via Tor/direct | — |

## Core

- DNS snooping DNSCrypt + FakeDNS → `DnsHostnameCache` (vidé à l’arrêt du tunnel)
- Matching des règles toujours sur IP packet ; hostname en `displayHost` UI-only
- Refresh listes : clearnet au boot si besoin, **re-fetch via Tor** dès que probe SOCKS est prêt

## CI

- `dependency-review` soft-fail si Dependency graph non activé

## Tests

Unit tests DNS parser + reputation index + compile debug OK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

