### PR TITLE
fix(tor): isolation Orbot-like + perf (rate-limit GitHub / lenteur)

### DIFF
--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/prefs/TunnelPreferencesStore.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/prefs/TunnelPreferencesStore.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import ltechnologies.onionphone.onionvpn.core.model.DnsResolverMode
 import ltechnologies.onionphone.onionvpn.core.model.FirewallDefaultAction
+import ltechnologies.onionphone.onionvpn.core.model.TorStreamIsolationMode
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
 
 private val Context.tunnelDataStore: DataStore<Preferences> by preferencesDataStore(name = "tunnel_prefs")
@@ -34,6 +35,7 @@ class TunnelPreferencesStore @Inject constructor(
         val torExclude = stringPreferencesKey("tor_exclude")
         val newCircuit = intPreferencesKey("tor_new_circuit")
         val maxDirtiness = intPreferencesKey("tor_max_dirtiness")
+        val streamIsolation = stringPreferencesKey("tor_stream_isolation")
         val requireNoLog = booleanPreferencesKey("dns_nolog")
         val requireNoFilter = booleanPreferencesKey("dns_nofilter")
         val forceTcp = booleanPreferencesKey("dns_force_tcp")
@@ -62,6 +64,7 @@ class TunnelPreferencesStore @Inject constructor(
             prefs[Keys.torExclude] = next.torExcludeNodes
             prefs[Keys.newCircuit] = next.torNewCircuitPeriodSec
             prefs[Keys.maxDirtiness] = next.torMaxCircuitDirtinessSec
+            prefs[Keys.streamIsolation] = next.torStreamIsolation.name
             prefs[Keys.requireNoLog] = next.dnsCryptRequireNoLog
             prefs[Keys.requireNoFilter] = next.dnsCryptRequireNoFilter
             prefs[Keys.forceTcp] = next.dnsCryptForceTcp
@@ -86,7 +89,10 @@ class TunnelPreferencesStore @Inject constructor(
         torExitNodes = this[Keys.torExit].orEmpty(),
         torExcludeNodes = this[Keys.torExclude].orEmpty(),
         torNewCircuitPeriodSec = this[Keys.newCircuit] ?: 30,
-        torMaxCircuitDirtinessSec = this[Keys.maxDirtiness] ?: 180,
+        torMaxCircuitDirtinessSec = this[Keys.maxDirtiness] ?: 600,
+        torStreamIsolation = this[Keys.streamIsolation]
+            ?.let { runCatching { TorStreamIsolationMode.valueOf(it) }.getOrNull() }
+            ?: TorStreamIsolationMode.BALANCED,
         dnsCryptRequireNoLog = this[Keys.requireNoLog] ?: true,
         dnsCryptRequireNoFilter = this[Keys.requireNoFilter] ?: false,
         dnsCryptForceTcp = this[Keys.forceTcp] ?: true,

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/service/TunnelForegroundService.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/service/TunnelForegroundService.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import ltechnologies.onionphone.onionvpn.core.dnscrypt.DnsCryptProcessManager
 import ltechnologies.onionphone.onionvpn.core.model.DnsResolverMode
+import ltechnologies.onionphone.onionvpn.core.model.TorStreamIsolationMode
 import ltechnologies.onionphone.onionvpn.core.model.TunnelEndpoints
 import ltechnologies.onionphone.onionvpn.core.model.TunnelFailure
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPhase
@@ -676,6 +677,7 @@ class TunnelForegroundService : Service() {
         const val EXTRA_TOR_EXCLUDE = "tor_exclude"
         const val EXTRA_TOR_NEW_CIRCUIT = "tor_new_circuit"
         const val EXTRA_TOR_MAX_DIRTINESS = "tor_max_dirtiness"
+        const val EXTRA_TOR_STREAM_ISOLATION = "tor_stream_isolation"
         const val EXTRA_DNS_NOLOG = "dns_nolog"
         const val EXTRA_DNS_NOFILTER = "dns_nofilter"
         const val EXTRA_DNS_FORCE_TCP = "dns_force_tcp"
@@ -709,7 +711,10 @@ class TunnelForegroundService : Service() {
             torExitNodes = intent.getStringExtra(EXTRA_TOR_EXIT).orEmpty(),
             torExcludeNodes = intent.getStringExtra(EXTRA_TOR_EXCLUDE).orEmpty(),
             torNewCircuitPeriodSec = intent.getIntExtra(EXTRA_TOR_NEW_CIRCUIT, 30),
-            torMaxCircuitDirtinessSec = intent.getIntExtra(EXTRA_TOR_MAX_DIRTINESS, 180),
+            torMaxCircuitDirtinessSec = intent.getIntExtra(EXTRA_TOR_MAX_DIRTINESS, 600),
+            torStreamIsolation = intent.getStringExtra(EXTRA_TOR_STREAM_ISOLATION)
+                ?.let { runCatching { TorStreamIsolationMode.valueOf(it) }.getOrNull() }
+                ?: TorStreamIsolationMode.BALANCED,
             dnsCryptRequireNoLog = intent.getBooleanExtra(EXTRA_DNS_NOLOG, true),
             dnsCryptRequireNoFilter = intent.getBooleanExtra(EXTRA_DNS_NOFILTER, false),
             dnsCryptForceTcp = intent.getBooleanExtra(EXTRA_DNS_FORCE_TCP, true),

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/tunnel/TunnelOrchestrator.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/tunnel/TunnelOrchestrator.kt
@@ -33,6 +33,7 @@ class TunnelOrchestrator @Inject constructor(
                 putExtra(TunnelForegroundService.EXTRA_TOR_EXCLUDE, preferences.torExcludeNodes)
                 putExtra(TunnelForegroundService.EXTRA_TOR_NEW_CIRCUIT, preferences.torNewCircuitPeriodSec)
                 putExtra(TunnelForegroundService.EXTRA_TOR_MAX_DIRTINESS, preferences.torMaxCircuitDirtinessSec)
+                putExtra(TunnelForegroundService.EXTRA_TOR_STREAM_ISOLATION, preferences.torStreamIsolation.name)
                 putExtra(TunnelForegroundService.EXTRA_DNS_NOLOG, preferences.dnsCryptRequireNoLog)
                 putExtra(TunnelForegroundService.EXTRA_DNS_NOFILTER, preferences.dnsCryptRequireNoFilter)
                 putExtra(TunnelForegroundService.EXTRA_DNS_FORCE_TCP, preferences.dnsCryptForceTcp)

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/SettingsScreen.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/SettingsScreen.kt
@@ -45,6 +45,7 @@ import ltechnologies.onionphone.onionvpn.R
 import ltechnologies.onionphone.onionvpn.core.dnscrypt.config.DnsCryptPublicResolvers
 import ltechnologies.onionphone.onionvpn.core.model.DnsResolverMode
 import ltechnologies.onionphone.onionvpn.core.model.FirewallDefaultAction
+import ltechnologies.onionphone.onionvpn.core.model.TorStreamIsolationMode
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
 import ltechnologies.onionphone.onionvpn.threat.DomainReputationRepository
 import ltechnologies.onionphone.onionvpn.util.SystemSecurityIntents
@@ -330,8 +331,41 @@ fun SettingsScreen(
 
         Text("Tor", style = MaterialTheme.typography.titleMedium)
         Text(
-            text = "Circuit rotation presets (tor-spec path-spec / MaxCircuitDirtiness). " +
-                "Vanguards-lite, padding, ClientOnly, SafeLogging already forced in torrc.",
+            text = "Stream isolation (apps → hev → Tor). Balanced matches Orbot: " +
+                "no IsolateDest* so same-host bursts (e.g. GitHub APIs) can spread across " +
+                "circuits. Strict pins one circuit per destination IP:port (slower, " +
+                "worse for API rate limits). Requires tunnel restart.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            FilterChip(
+                selected = local.torStreamIsolation == TorStreamIsolationMode.BALANCED,
+                onClick = {
+                    commit(
+                        local.copy(torStreamIsolation = TorStreamIsolationMode.BALANCED),
+                        restart = true,
+                    )
+                },
+                label = { Text("Isolation: Balanced") },
+            )
+            FilterChip(
+                selected = local.torStreamIsolation == TorStreamIsolationMode.STRICT,
+                onClick = {
+                    commit(
+                        local.copy(torStreamIsolation = TorStreamIsolationMode.STRICT),
+                        restart = true,
+                    )
+                },
+                label = { Text("Isolation: Strict") },
+            )
+        }
+        Text(
+            text = "Circuit rotation presets (tor-spec MaxCircuitDirtiness). " +
+                "Vanguards-lite, reduced padding, ClientOnly, SafeLogging forced in torrc.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -341,6 +375,20 @@ fun SettingsScreen(
         ) {
             FilterChip(
                 selected = local.torNewCircuitPeriodSec == 30 &&
+                    local.torMaxCircuitDirtinessSec == 600,
+                onClick = {
+                    commit(
+                        local.copy(
+                            torNewCircuitPeriodSec = 30,
+                            torMaxCircuitDirtinessSec = 600,
+                        ),
+                        restart = true,
+                    )
+                },
+                label = { Text("Rotation: Orbot-like") },
+            )
+            FilterChip(
+                selected = local.torNewCircuitPeriodSec == 30 &&
                     local.torMaxCircuitDirtinessSec == 180,
                 onClick = {
                     commit(
@@ -348,9 +396,10 @@ fun SettingsScreen(
                             torNewCircuitPeriodSec = 30,
                             torMaxCircuitDirtinessSec = 180,
                         ),
+                        restart = true,
                     )
                 },
-                label = { Text("Balanced") },
+                label = { Text("Rotation: Faster") },
             )
             FilterChip(
                 selected = local.torNewCircuitPeriodSec == 15 &&
@@ -361,9 +410,10 @@ fun SettingsScreen(
                             torNewCircuitPeriodSec = 15,
                             torMaxCircuitDirtinessSec = 60,
                         ),
+                        restart = true,
                     )
                 },
-                label = { Text("Paranoid") },
+                label = { Text("Rotation: Paranoid") },
             )
         }
         OutlinedTextField(

--- a/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/TunnelModels.kt
+++ b/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/TunnelModels.kt
@@ -40,9 +40,9 @@ object TunnelEndpoints {
 
     /**
      * SOCKS5 credentials for hev → Tor IsolateSOCKSAuth (app traffic circuits).
-     * hev uses one token for all TUN streams — circuit separation relies on
-     * IsolateDestAddr/IsolateDestPort (path-spec); KeepAliveIsolateSOCKSAuth is
-     * intentionally off on the app SocksPort so MaxCircuitDirtiness rotates.
+     * hev uses one token for all TUN streams — IsolateSOCKSAuth alone cannot
+     * separate apps. Circuit policy is [TorStreamIsolationMode] on the apps
+     * SocksPort; KeepAliveIsolateSOCKSAuth stays off so MaxCircuitDirtiness rotates.
      */
     const val SOCKS_ISOLATION_USER = "onionvpn"
     const val SOCKS_ISOLATION_PASS = "stream"
@@ -74,6 +74,23 @@ object TunnelEndpoints {
 enum class DnsResolverMode {
     DNSCRYPT_MUX,
     FAKE_IP_SOCKS5A,
+}
+
+/**
+ * How aggressively Tor isolates app (hev) streams.
+ *
+ * - [BALANCED]: Orbot-like — no IsolateDestAddr/Port on the apps SocksPort.
+ *   Same-host bursts (e.g. Obtainium → api.github.com) can use multiple circuits
+ *   as Tor builds them, which spreads exit-IP rate limits and cuts circuit thrash.
+ * - [STRICT]: IsolateDestAddr + IsolateDestPort — one circuit per destination.
+ *   Stronger unlinkability between hosts, but pins APIs to a single exit and is slower.
+ *
+ * hev uses one static SOCKS user/pass, so IsolateSOCKSAuth alone cannot separate
+ * apps; SessionGroup still keeps apps ⟂ DNSCrypt ⟂ probes.
+ */
+enum class TorStreamIsolationMode {
+    BALANCED,
+    STRICT,
 }
 
 /**

--- a/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/TunnelPreferences.kt
+++ b/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/TunnelPreferences.kt
@@ -15,8 +15,11 @@ data class TunnelPreferences(
     val torEntryNodes: String = "",
     val torExitNodes: String = "",
     val torExcludeNodes: String = "",
+    /** Tor default-ish; was 30/180 and caused excess circuit churn vs Orbot. */
     val torNewCircuitPeriodSec: Int = 30,
-    val torMaxCircuitDirtinessSec: Int = 180,
+    val torMaxCircuitDirtinessSec: Int = 600,
+    /** Apps SocksPort isolation — see [TorStreamIsolationMode]. */
+    val torStreamIsolation: TorStreamIsolationMode = TorStreamIsolationMode.BALANCED,
     val dnsCryptRequireNoLog: Boolean = true,
     val dnsCryptRequireNoFilter: Boolean = false,
     val dnsCryptForceTcp: Boolean = true,

--- a/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/config/TorConfigWriter.kt
+++ b/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/config/TorConfigWriter.kt
@@ -2,6 +2,7 @@ package ltechnologies.onionphone.onionvpn.core.tor.config
 
 import java.io.File
 import ltechnologies.onionphone.onionvpn.core.model.DnsResolverMode
+import ltechnologies.onionphone.onionvpn.core.model.TorStreamIsolationMode
 import ltechnologies.onionphone.onionvpn.core.model.TunnelEndpoints
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
 
@@ -17,8 +18,9 @@ import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
  * and MITM hardening.
  *
  * Isolation model:
- * 1. Apps/hev — SessionGroup apps, IsolateDestAddr+Port, no KeepAliveIsolateSOCKSAuth
- * 2. DNSCrypt — own SessionGroup + KeepAliveIsolateSOCKSAuth
+ * 1. Apps/hev — SessionGroup apps; [TorStreamIsolationMode] controls IsolateDest*;
+ *    never KeepAliveIsolateSOCKSAuth (shared hev auth must not pin circuits forever)
+ * 2. DNSCrypt — own SessionGroup + KeepAliveIsolateSOCKSAuth + dest isolation
  * 3. Probes — dedicated SocksPort (never share circuits with user traffic)
  * 4. DNSPort — Automap / bootstrap SessionGroup
  *
@@ -38,11 +40,21 @@ object TorConfigWriter {
     const val COOKIE_FILE_NAME = "control_auth_cookie"
 
     /**
-     * Maximal SOCKS isolation flags (path-spec + Tor man).
-     * Applied to every SocksPort; apps omit KeepAliveIsolateSOCKSAuth separately.
+     * Full dest isolation (path-spec). Used for DNSCrypt/probe and apps in STRICT mode.
      */
-    const val SOCKS_ISOLATION_MAX =
+    const val SOCKS_ISOLATION_STRICT =
         "IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort IsolateSOCKSAuth"
+
+    /**
+     * Orbot-like apps isolation: auth/client flags only — no IsolateDest*.
+     * Lets Tor attach same-host streams to different circuits over time (rate-limit
+     * spreading) and avoids circuit storms under multi-host browsing.
+     */
+    const val SOCKS_ISOLATION_BALANCED =
+        "IsolateClientAddr IsolateClientProtocol IsolateSOCKSAuth"
+
+    /** @deprecated Use [SOCKS_ISOLATION_STRICT]. Kept for call-site compatibility. */
+    const val SOCKS_ISOLATION_MAX = SOCKS_ISOLATION_STRICT
 
     /**
      * @param dataDirectory absolute Tor DataDirectory path
@@ -70,18 +82,22 @@ object TorConfigWriter {
         appendLine("SocksPolicy accept 127.0.0.1")
         appendLine("SocksPolicy reject *")
 
+        val appsIsolation = when (preferences.torStreamIsolation) {
+            TorStreamIsolationMode.BALANCED -> SOCKS_ISOLATION_BALANCED
+            TorStreamIsolationMode.STRICT -> SOCKS_ISOLATION_STRICT
+        }
         appendLine(
             "SOCKSPort ${TunnelEndpoints.LOOPBACK}:$socksPort " +
-                "SessionGroup=${TunnelEndpoints.SESSION_GROUP_APPS} $SOCKS_ISOLATION_MAX",
+                "SessionGroup=${TunnelEndpoints.SESSION_GROUP_APPS} $appsIsolation",
         )
         appendLine(
             "SOCKSPort ${TunnelEndpoints.LOOPBACK}:$dnsCryptSocksPort " +
-                "SessionGroup=${TunnelEndpoints.SESSION_GROUP_DNSCRYPT} $SOCKS_ISOLATION_MAX " +
+                "SessionGroup=${TunnelEndpoints.SESSION_GROUP_DNSCRYPT} $SOCKS_ISOLATION_STRICT " +
                 "KeepAliveIsolateSOCKSAuth",
         )
         appendLine(
             "SOCKSPort ${TunnelEndpoints.LOOPBACK}:$probeSocksPort " +
-                "SessionGroup=${TunnelEndpoints.SESSION_GROUP_PROBE} $SOCKS_ISOLATION_MAX",
+                "SessionGroup=${TunnelEndpoints.SESSION_GROUP_PROBE} $SOCKS_ISOLATION_STRICT",
         )
         appendLine(
             "DNSPort ${TunnelEndpoints.LOOPBACK}:$dnsPort " +
@@ -120,15 +136,18 @@ object TorConfigWriter {
         appendLine("EnforceDistinctSubnets 1")
         appendLine("StrictNodes 0")
 
-        appendLine("MaxClientCircuitsPending 128")
+        // Orbot-scale pending budget — 128 + IsolateDest* caused circuit storms.
+        appendLine("MaxClientCircuitsPending 32")
         appendLine("CircuitBuildTimeout 60")
         appendLine("LearnCircuitBuildTimeout 1")
         appendLine("SocksTimeout 120")
+        appendLine("CircuitStreamTimeout 30")
 
+        // Orbot defaults: reduced padding (less battery/bandwidth overhead).
         appendLine("ConnectionPadding auto")
-        appendLine("ReducedConnectionPadding 0")
+        appendLine("ReducedConnectionPadding 1")
         appendLine("CircuitPadding 1")
-        appendLine("ReducedCircuitPadding 0")
+        appendLine("ReducedCircuitPadding 1")
 
         appendLine("WarnPlaintextPorts 23,109,110,143")
         appendLine("RejectPlaintextPorts 23,109")

--- a/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/control/catalog/TorControlCatalog.kt
+++ b/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/control/catalog/TorControlCatalog.kt
@@ -99,7 +99,8 @@ object TorControlCatalog {
     enum class Event(val wire: String, val tier: EventTier) {
         CIRC("CIRC", EventTier.CORE),
         CIRC_MINOR("CIRC_MINOR", EventTier.OPTIONAL),
-        STREAM("STREAM", EventTier.CORE),
+        // STREAM floods the control reader under browse storms; keep optional.
+        STREAM("STREAM", EventTier.OPTIONAL),
         ORCONN("ORCONN", EventTier.CORE),
         BW("BW", EventTier.CORE),
         NOTICE("NOTICE", EventTier.CORE),
@@ -134,7 +135,7 @@ object TorControlCatalog {
     private fun eventsOf(tier: EventTier): String =
         Event.entries.filter { it.tier == tier }.joinToString(" ") { it.wire }
 
-    /** Core SETEVENTS — Orbot-like; must be accepted by stock Tor. */
+    /** Core SETEVENTS — lean set (STREAM is optional to avoid control floods). */
     val CLIENT_EVENTS: String get() = eventsOf(EventTier.CORE)
 
     /** Optional extras tried after core succeeds (best-effort, incremental). */

--- a/core/tor/src/test/java/ltechnologies/onionphone/onionvpn/core/tor/config/TorConfigWriterTest.kt
+++ b/core/tor/src/test/java/ltechnologies/onionphone/onionvpn/core/tor/config/TorConfigWriterTest.kt
@@ -1,5 +1,6 @@
 package ltechnologies.onionphone.onionvpn.core.tor.config
 
+import ltechnologies.onionphone.onionvpn.core.model.TorStreamIsolationMode
 import ltechnologies.onionphone.onionvpn.core.model.TunnelEndpoints
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
 import org.junit.Assert.assertFalse
@@ -8,14 +9,17 @@ import org.junit.Test
 
 class TorConfigWriterTest {
     @Test
-    fun streamIsolation_maxFlags_threeSocksPorts_noKeepAliveOnApps() {
+    fun streamIsolation_balancedApps_noDestIsolation_noKeepAliveOnApps() {
         val torrc = TorConfigWriter.write(
             dataDirectory = "/tmp/tor",
             socksPort = 1111,
             dnsCryptSocksPort = 2222,
             probeSocksPort = 3333,
             dnsPort = 4444,
-            preferences = TunnelPreferences(torMaxCircuitDirtinessSec = 180),
+            preferences = TunnelPreferences(
+                torMaxCircuitDirtinessSec = 600,
+                torStreamIsolation = TorStreamIsolationMode.BALANCED,
+            ),
         )
 
         assertTrue(torrc.contains("SOCKSPort ${TunnelEndpoints.LOOPBACK}:1111"))
@@ -24,18 +28,21 @@ class TorConfigWriterTest {
         assertTrue(torrc.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_APPS}"))
         assertTrue(torrc.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_DNSCRYPT}"))
         assertTrue(torrc.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_PROBE}"))
-        assertTrue(torrc.contains("IsolateClientAddr"))
-        assertTrue(torrc.contains("IsolateClientProtocol"))
-        assertTrue(torrc.contains("IsolateDestAddr"))
-        assertTrue(torrc.contains("IsolateDestPort"))
         assertTrue(torrc.contains("IsolateSOCKSAuth"))
-        assertTrue(torrc.contains("MaxClientCircuitsPending 128"))
-        assertTrue(torrc.contains("MaxCircuitDirtiness 180"))
+        assertTrue(torrc.contains("MaxClientCircuitsPending 32"))
+        assertTrue(torrc.contains("MaxCircuitDirtiness 600"))
+        assertTrue(torrc.contains("CircuitStreamTimeout 30"))
+        assertTrue(torrc.contains("ReducedConnectionPadding 1"))
+        assertTrue(torrc.contains("ReducedCircuitPadding 1"))
 
         val appLine = torrc.lineSequence().first {
             it.startsWith("SOCKSPort ") &&
                 it.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_APPS}")
         }
+        assertFalse(
+            "Balanced apps SocksPort must not pin destinations (Orbot-like)",
+            appLine.contains("IsolateDestAddr") || appLine.contains("IsolateDestPort"),
+        )
         assertFalse(
             "KeepAliveIsolateSOCKSAuth on app SocksPort would pin shared hev auth circuits",
             appLine.contains("KeepAliveIsolateSOCKSAuth"),
@@ -45,6 +52,24 @@ class TorConfigWriterTest {
                 it.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_DNSCRYPT}")
         }
         assertTrue(dnsCryptLine.contains("KeepAliveIsolateSOCKSAuth"))
+        assertTrue(dnsCryptLine.contains("IsolateDestAddr"))
+    }
+
+    @Test
+    fun streamIsolation_strictApps_hasDestIsolation() {
+        val torrc = TorConfigWriter.write(
+            dataDirectory = "/tmp/tor",
+            preferences = TunnelPreferences(
+                torStreamIsolation = TorStreamIsolationMode.STRICT,
+            ),
+        )
+        val appLine = torrc.lineSequence().first {
+            it.startsWith("SOCKSPort ") &&
+                it.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_APPS}")
+        }
+        assertTrue(appLine.contains("IsolateDestAddr"))
+        assertTrue(appLine.contains("IsolateDestPort"))
+        assertFalse(appLine.contains("KeepAliveIsolateSOCKSAuth"))
     }
 
     @Test

--- a/core/tor/src/test/java/ltechnologies/onionphone/onionvpn/core/tor/control/catalog/TorControlCatalogTest.kt
+++ b/core/tor/src/test/java/ltechnologies/onionphone/onionvpn/core/tor/control/catalog/TorControlCatalogTest.kt
@@ -12,7 +12,6 @@ class TorControlCatalogTest {
         listOf(
             "STATUS_CLIENT",
             "CIRC",
-            "STREAM",
             "ORCONN",
             "BW",
             "ADDRMAP",
@@ -23,6 +22,7 @@ class TorControlCatalogTest {
         ).forEach { name ->
             assertTrue("$name missing from CLIENT_EVENTS", events.contains(name))
         }
+        assertFalse("STREAM must stay optional (control flood under browse storms)", events.contains("STREAM"))
         assertFalse("PT events must not be in core SETEVENTS", events.contains("PT_LOG"))
         assertFalse(events.contains("TRANSPORT_LAUNCHED"))
         assertFalse(events.contains("CIRC_MINOR"))
@@ -39,6 +39,7 @@ class TorControlCatalogTest {
         assertTrue(optional.intersect(pt).isEmpty())
         assertTrue(pt.containsAll(listOf("TRANSPORT_LAUNCHED", "PT_LOG", "PT_STATUS")))
         assertTrue(optional.contains("CIRC_MINOR"))
+        assertTrue(optional.contains("STREAM"))
     }
 
     @Test

--- a/core/validation/src/main/java/ltechnologies/onionphone/onionvpn/core/validation/path/TorPathValidator.kt
+++ b/core/validation/src/main/java/ltechnologies/onionphone/onionvpn/core/validation/path/TorPathValidator.kt
@@ -53,11 +53,18 @@ object TorPathValidator {
         val safeLogging = config.contains("SafeLogging 1")
         val refuseUnknownExits = config.contains("RefuseUnknownExits 1")
         val controlSocket = config.contains("ControlSocket ") && config.contains("CookieAuthentication 1")
-        val socksIsolation = config.contains("IsolateDestAddr") &&
-            config.contains("IsolateDestPort") &&
-            config.contains("IsolateSOCKSAuth") &&
-            config.contains("IsolateClientAddr") &&
-            config.contains("IsolateClientProtocol")
+        // Apps may be BALANCED (no IsolateDest*) or STRICT; DNSCrypt/probe keep dest isolation.
+        val hasAppsAuthIsolation = config.lineSequence().any {
+            it.startsWith("SOCKSPort ") &&
+                it.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_APPS}") &&
+                it.contains("IsolateSOCKSAuth")
+        }
+        val dnsCryptIsolated = config.lineSequence().any {
+            it.startsWith("SOCKSPort ") &&
+                it.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_DNSCRYPT}") &&
+                it.contains("IsolateDestAddr") &&
+                it.contains("KeepAliveIsolateSOCKSAuth")
+        }
         val socksPolicy = config.contains("SocksPolicy accept 127.0.0.1") &&
             config.contains("SocksPolicy reject *")
         // Apps + DNSCrypt + probe SocksPorts (path-spec proxy-address isolation).
@@ -66,6 +73,7 @@ object TorPathValidator {
         val noKeepAliveOnApps = !config.lineSequence()
             .filter { it.startsWith("SOCKSPort ") && it.contains("SessionGroup=${TunnelEndpoints.SESSION_GROUP_APPS}") }
             .any { it.contains("KeepAliveIsolateSOCKSAuth") }
+        val socksIsolation = hasAppsAuthIsolation && dnsCryptIsolated
         val ok = hasSocks && hasDns && safeSocksSet && clientOnly &&
             entryGuards && socksIsolation && socksPolicy && multiSocks &&
             hasProbeGroup && noKeepAliveOnApps && rejectInternal && safeLogging &&

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/HevSocks5TunForwarder.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/HevSocks5TunForwarder.kt
@@ -125,8 +125,9 @@ class HevSocks5TunForwarder(
         appendLine("  address: '$socksHost'")
         // Force UDP associate over TCP — no clearnet UDP side-channel.
         appendLine("  udp: 'tcp'")
-        // IsolateSOCKSAuth token for hev (static — hev has no per-stream auth).
-        // Per-destination circuits come from Tor IsolateDestAddr/IsolateDestPort.
+        // Shared IsolateSOCKSAuth token (hev has no per-stream auth).
+        // Circuit diversity for apps comes from TorStreamIsolationMode on the
+        // apps SocksPort + MaxCircuitDirtiness — not from this static credential.
         appendLine("  username: '${TunnelEndpoints.SOCKS_ISOLATION_USER}'")
         appendLine("  password: '${TunnelEndpoints.SOCKS_ISOLATION_PASS}'")
         if (useMapDns) {

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/TunDnsMux.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/TunDnsMux.kt
@@ -50,6 +50,13 @@ class TunDnsMux(
     private val dnsCryptAddress: InetAddress = InetAddress.getByName(dnsCryptHost)
     private val packetPool = ArrayBlockingQueue<ByteArray>(DNS_QUEUE_CAP)
 
+    /** Per-mux (not static) — avoids FD leaks / QNAME cross-talk across reconnects. */
+    private val dnsScratch = ThreadLocal.withInitial { DnsScratch() }
+    private val pendingQnames = java.util.concurrent.ConcurrentHashMap<Int, String>(64)
+    private val liveDnsSockets = java.util.Collections.newSetFromMap(
+        java.util.concurrent.ConcurrentHashMap<DatagramSocket, Boolean>(),
+    )
+
     private val dnsExecutor = ThreadPoolExecutor(
         DNS_CORE_THREADS,
         DNS_MAX_THREADS,
@@ -179,6 +186,10 @@ class TunDnsMux(
         // FakeDNS IPs are reused across sessions — drop stale IP→host bindings.
         pendingQnames.clear()
         DnsHostnameCache.clear()
+        // Close ThreadLocal DNSCrypt sockets so reconnects do not leak FDs.
+        liveDnsSockets.toList().forEach { runCatching { it.close() } }
+        liveDnsSockets.clear()
+        dnsScratch.remove()
         runCatching {
             if (!dnsExecutor.awaitTermination(2, TimeUnit.SECONDS)) {
                 Timber.w("DNS executor did not terminate cleanly")
@@ -390,7 +401,7 @@ class TunDnsMux(
         return sum.inv() and 0xffff
     }
 
-    private class DnsScratch {
+    private inner class DnsScratch {
         val responseBuf = ByteArray(DNS_RESPONSE_CAP)
         val replyBuf = ByteArray(MTU)
         private var socket: DatagramSocket? = null
@@ -401,6 +412,7 @@ class TunDnsMux(
             return DatagramSocket().also {
                 it.soTimeout = DNS_TIMEOUT_MS
                 socket = it
+                liveDnsSockets.add(it)
             }
         }
     }
@@ -410,17 +422,12 @@ class TunDnsMux(
         private const val PROTO_UDP = 17
         private const val DNS_TIMEOUT_MS = 8_000
         private const val DNS_RESPONSE_CAP = 2048
-        private const val EMPTY_READ_PARK_NS = 200_000L // 0.2ms
+        /** Avoid near-spin if the TUN fd ever returns 0-length reads. */
+        private const val EMPTY_READ_PARK_NS = 1_000_000L // 1ms
         private val DNS_CORE_THREADS =
             Runtime.getRuntime().availableProcessors().coerceIn(2, 4)
         private val DNS_MAX_THREADS = (DNS_CORE_THREADS + 2).coerceAtMost(6)
         private const val DNS_QUEUE_CAP = 64
         private const val PENDING_QNAME_CAP = 512
-
-        private val dnsScratch = ThreadLocal.withInitial { DnsScratch() }
-
-        /** queryId → QNAME for FakeDNS responses that rely on query correlation. */
-        private val pendingQnames =
-            java.util.concurrent.ConcurrentHashMap<Int, String>(64)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problème

Avec Obtainium, un rate-limit GitHub apparaissait, et Tor semblait nettement plus lent qu’Orbot.

## Cause

1. **Rate-limit** — `IsolateDestAddr` + `IsolateDestPort` sur le SocksPort apps forçaient **un seul circuit/exit** pour toutes les connexions vers `api.github.com:443`. hev n’a qu’un seul user/pass SOCKS → `IsolateSOCKSAuth` est inerte pour les apps.
2. **Lenteur** — isolation max + `MaxCircuitDirtiness 180` + padding non réduit + flood d’events `STREAM` + sockets DNS ThreadLocal non fermés.

## Correctifs

- **Isolation Balanced (défaut, Orbot-like)** : plus d’`IsolateDest*` sur le SocksPort apps → Tor peut répartir les streams same-host sur plusieurs circuits.
- **Isolation Strict (opt-in Settings)** : ancien comportement IsolatesDest*.
- Dirtiness défaut **600**, reduced padding, `MaxClientCircuitsPending 32`, `CircuitStreamTimeout 30`.
- `STREAM` retiré du SETEVENTS core (optionnel).
- TunDnsMux : sockets DNSCrypt fermés à l’arrêt, state par instance (plus de static leak).

## Settings

Nouveaux chips : Isolation Balanced/Strict + Rotation Orbot-like/Faster/Paranoid (restart tunnel requis).

## Note

hev ne peut pas isoler *par requête* ; pour un API unique, Balanced + rotation de circuits / NEWNYM reste le levier réaliste. DNSCrypt/probes gardent l’isolation stricte (SessionGroups séparés).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

