### PR TITLE
fix(firewall): always show threat emoji on connection notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "ltechnologies.onionphone.onionvpn"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 11
-        versionName = "0.3.4"
+        versionCode = 12
+        versionName = "0.3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
@@ -47,14 +47,9 @@ internal class FirewallPromptNotifier(
 
     fun show(info: FirewallConnectionInfo) {
         ensureChannel()
-        // Notification body text cannot reliably use coloured spans across OEMs.
-        // Prefix only known threats (unknown stays unmarked — never imply "safe").
-        val emoji = info.threatCategory.notificationEmojiOrNull()
-        val dest = if (emoji != null) {
-            "$emoji ${info.displayDestination()}"
-        } else {
-            info.displayDestination()
-        }
+        // Notification body text cannot reliably use coloured spans across OEMs —
+        // always prefix the destination with 🟢 / 🟠 / 🔴.
+        val dest = "${info.threatCategory.notificationEmoji()} ${info.displayDestination()}"
         val base = appContext.getString(
             R.string.firewall_prompt_notif_text,
             info.protocolLabel,

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/ThreatUi.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/ThreatUi.kt
@@ -27,9 +27,12 @@ fun threatLabelOrNull(category: DomainThreatCategory): String? = when (category)
     DomainThreatCategory.NONE -> null
 }
 
-/** Notification-safe marker — coloured spans are unreliable on Android OEMs. */
-fun DomainThreatCategory.notificationEmojiOrNull(): String? = when (this) {
-    DomainThreatCategory.NONE -> null
+/**
+ * Notification-safe marker next to the domain (coloured spans are unreliable on OEMs).
+ * Always returns an emoji so the destination line is never unmarked.
+ */
+fun DomainThreatCategory.notificationEmoji(): String = when (this) {
+    DomainThreatCategory.NONE -> "🟢"
     DomainThreatCategory.TRACKING -> "🟠"
     DomainThreatCategory.MALWARE -> "🔴"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
In v0.3.4 the connection-request notification only prefixed 🟠/🔴 when the domain was on a threat list. Most prompts therefore showed **no emoji** next to the domain.

This always prefixes the destination with:
- 🟢 unknown / not listed
- 🟠 tracking / ads / telemetry
- 🔴 malware / C2

Also bumps version to **0.3.5** (`versionCode` 12) for release.

## Test plan
- [ ] Install 0.3.5 APK
- [ ] Trigger a firewall connection prompt for a normal domain → notification shows `🟢 domain.tld`
- [ ] Trigger for a tracking domain (lists updated) → `🟠 …`
- [ ] Trigger for malware list hit → `🔴 …`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

