### PR TITLE
fix(firewall): green=safe, orange=tracking, red=malware on domain prompts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "ltechnologies.onionphone.onionvpn"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 12
-        versionName = "0.3.5"
+        versionCode = 13
+        versionName = "0.3.6"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptContent.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptContent.kt
@@ -78,7 +78,7 @@ fun FirewallPromptContent(
         }
 
         Text(
-            "${info.protocolLabel} → ${info.displayDestination()}:${info.destPort}",
+            "${info.protocolLabel} → ${info.threatCategory.notificationEmoji()} ${info.displayDestination()}:${info.destPort}",
             style = MaterialTheme.typography.titleMedium,
             color = destColor,
             fontWeight = if (info.threatCategory != DomainThreatCategory.NONE) {

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
@@ -47,8 +47,8 @@ internal class FirewallPromptNotifier(
 
     fun show(info: FirewallConnectionInfo) {
         ensureChannel()
-        // Notification body text cannot reliably use coloured spans across OEMs —
-        // always prefix the destination with 🟢 / 🟠 / 🔴.
+        // Coloured spans are unreliable on OEMs — emoji next to the domain:
+        // 🟢 sûr (pas tracking/malware) · 🟠 tracking · 🔴 malware
         val dest = "${info.threatCategory.notificationEmoji()} ${info.displayDestination()}"
         val base = appContext.getString(
             R.string.firewall_prompt_notif_text,

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/ThreatUi.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/ThreatUi.kt
@@ -7,8 +7,15 @@ import androidx.compose.ui.res.stringResource
 import ltechnologies.onionphone.onionvpn.R
 import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
 
-/** Shared threat colours for Compose firewall surfaces (prompt + journal). */
+/**
+ * Threat colours for firewall surfaces.
+ *
+ * - Green = sûr (pas listé tracking/malware)
+ * - Orange = tracking / pubs / télémétrie
+ * - Red = malware / C2
+ */
 object ThreatColors {
+    val Green = Color(0xFF2E7D32)
     val Orange = Color(0xFFE65100)
     val Red = Color(0xFFC62828)
 }
@@ -17,7 +24,7 @@ object ThreatColors {
 fun threatTextColor(category: DomainThreatCategory): Color = when (category) {
     DomainThreatCategory.MALWARE -> ThreatColors.Red
     DomainThreatCategory.TRACKING -> ThreatColors.Orange
-    DomainThreatCategory.NONE -> MaterialTheme.colorScheme.onSurface
+    DomainThreatCategory.NONE -> ThreatColors.Green
 }
 
 @Composable
@@ -28,8 +35,12 @@ fun threatLabelOrNull(category: DomainThreatCategory): String? = when (category)
 }
 
 /**
- * Notification-safe marker next to the domain (coloured spans are unreliable on OEMs).
- * Always returns an emoji so the destination line is never unmarked.
+ * Emoji next to the domain in the connection-request notification
+ * (coloured spans are unreliable on Android OEMs).
+ *
+ * - 🟢 domaine sûr (pas tagué tracking/malware)
+ * - 🟠 tracking / pubs / télémétrie
+ * - 🔴 malware / C2
  */
 fun DomainThreatCategory.notificationEmoji(): String = when (this) {
     DomainThreatCategory.NONE -> "🟢"

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/FirewallScreen.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/ui/FirewallScreen.kt
@@ -143,10 +143,7 @@ private fun JournalRow(entry: FirewallJournalEntry) {
     val time = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
         .format(Date(entry.timestampEpochMs))
     val threatLabel = threatLabelOrNull(entry.threatCategory)
-    val destColor = when (entry.threatCategory) {
-        DomainThreatCategory.NONE -> MaterialTheme.colorScheme.onSurfaceVariant
-        else -> threatTextColor(entry.threatCategory)
-    }
+    val destColor = threatTextColor(entry.threatCategory)
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
             "$time  ${verdictLabel(entry.verdict)}  ${entry.appLabel}",

--- a/app/src/test/java/ltechnologies/onionphone/onionvpn/firewall/ThreatEmojiTest.kt
+++ b/app/src/test/java/ltechnologies/onionphone/onionvpn/firewall/ThreatEmojiTest.kt
@@ -1,0 +1,17 @@
+package ltechnologies.onionphone.onionvpn.firewall
+
+import ltechnologies.onionphone.onionvpn.core.model.DomainThreatCategory
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThreatEmojiTest {
+    @Test
+    fun notificationEmojiMatchesThreatCategory() {
+        // 🟢 safe (not tagged tracking/malware)
+        assertEquals("🟢", DomainThreatCategory.NONE.notificationEmoji())
+        // 🟠 tracking / ads / telemetry
+        assertEquals("🟠", DomainThreatCategory.TRACKING.notificationEmoji())
+        // 🔴 malware / C2
+        assertEquals("🔴", DomainThreatCategory.MALWARE.notificationEmoji())
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Locks the threat marker next to the domain name:

| Emoji | Meaning |
|-------|---------|
| 🟢 | Domaine **sûr** (pas tagué tracking/malware) |
| 🟠 | Tracking / pubs / télémétrie |
| 🔴 | Malware / C2 |

Also applies green text colour for safe domains in the prompt/journal, shows the same emoji in the prompt activity, and adds a unit test for the mapping. Version **0.3.6**.

## Test plan
- [ ] Update domain lists in Settings
- [ ] Safe domain prompt → `🟢 example.com` (green)
- [ ] Known tracker → `🟠 …` (orange)
- [ ] Malware list hit → `🔴 …` (red)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

