### PR TITLE
docs(readme): refresh OnionVPN application description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # OnionVPN
 
-Tor + DNSCrypt VPN for Android (InviZible / Mullvad-inspired). Traffic is forced through Tor; app DNS goes through DNSCrypt over Tor SOCKS (default), with FakeDNS/SOCKS5A as a settings fallback.
+Privacy-focused Android VPN that routes **all device traffic through Tor**, with **DNSCrypt** for app DNS (over Tor SOCKS by default; FakeDNS / SOCKS5A as a settings fallback). Inspired by InviZible and Mullvad-style leak protection.
 
 **Package:** `ltechnologies.onionphone.onionvpn`  
 **Min SDK 26 · Target / Compile SDK 37 · Java/Kotlin 21 · Jetpack Compose**
+
+### What it does
+
+| Feature | Description |
+|---------|-------------|
+| Tor tunnel | Full-device VPN via hev-socks5-tunnel → Tor SOCKS; kill switch blocks traffic when the tunnel is down |
+| DNSCrypt | App DNS resolved through DNSCrypt (upstream via Tor); TunDnsMux on `10.8.0.1` |
+| Interactive firewall | OpenSnitch-style Accept / Deny for new outbound connections (notification + prompt, FIFO queue, permanent / session / temporary rules) |
+| Domain threat lists | HaGeZi lists colour destinations on prompts: 🟢 safe (unlisted), 🟠 ads/tracking/telemetry, 🔴 malware/C2 — updates prefer Tor when the tunnel is up |
+| App lock | Lock the UI without stopping the tunnel or kill switch |
+| Tor tuning | Circuit rotation presets, stream isolation modes, editable `torrc` / `dnscrypt-proxy.toml` |
 
 ## Architecture
 
@@ -12,6 +23,7 @@ Tor + DNSCrypt VPN for Android (InviZible / Mullvad-inspired). Traffic is forced
 | Tor | SOCKS + DNSPort (ephemeral ports), SafeSocks depending on DNS mode |
 | DNSCrypt | App DNS via TunDnsMux; upstream via Tor SOCKS; bootstrap via Tor DNSPort |
 | VPN | `OnionVpnService` + hev-socks5-tunnel; client `10.8.0.2`, DNS `10.8.0.1` |
+| Firewall | `InteractiveFirewallEngine` on the TUN; DNS hostname cache + HaGeZi reputation for prompt UI |
 
 Modules: `app`, `core:model`, `core:tor`, `core:dnscrypt`, `core:vpn`, `core:validation`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the README intro so it matches what OnionVPN actually ships today:

- Tor full-device tunnel + kill switch
- DNSCrypt over Tor
- Interactive firewall (Accept/Deny prompts)
- HaGeZi domain threat markers (🟢/🟠/🔴)
- App lock and Tor tuning

Also adds a Firewall row to the architecture table.

## Test plan
- [ ] Skim README on GitHub — intro and feature table read clearly

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90e96d86-5603-4ccb-9ff5-31b2f3f256f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

