### PR TITLE
feat(firewall,tor): DPI sur les demandes d’autorisation + bande passante tous circuits

### DIFF
--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptContent.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptContent.kt
@@ -87,6 +87,14 @@ fun FirewallPromptContent(
                 FontWeight.Normal
             },
         )
+        val dpiDetail = info.dpiDetail
+        if (!dpiDetail.isNullOrBlank()) {
+            Text(
+                dpiDetail,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         if (!info.destHost.isNullOrBlank()) {
             Text(
                 "IP ${info.destIp}",

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/FirewallPromptNotifier.kt
@@ -49,6 +49,7 @@ internal class FirewallPromptNotifier(
         ensureChannel()
         // Coloured spans are unreliable on OEMs — emoji next to the domain:
         // 🟢 sûr (pas tracking/malware) · 🟠 tracking · 🔴 malware
+        // protocolLabel is DPI-enhanced (DNS / HTTP / HTTPS / TLS / QUIC / TCP / UDP).
         val dest = "${info.threatCategory.notificationEmoji()} ${info.displayDestination()}"
         val base = appContext.getString(
             R.string.firewall_prompt_notif_text,
@@ -56,6 +57,7 @@ internal class FirewallPromptNotifier(
             dest,
             info.destPort,
         )
+        val dpiSuffix = info.dpiDetail?.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()
         val threatSuffix = when (info.threatCategory) {
             DomainThreatCategory.MALWARE ->
                 " · " + appContext.getString(R.string.firewall_threat_malware)
@@ -63,7 +65,7 @@ internal class FirewallPromptNotifier(
                 " · " + appContext.getString(R.string.firewall_threat_tracking)
             DomainThreatCategory.NONE -> ""
         }
-        val content = base + threatSuffix
+        val content = base + dpiSuffix + threatSuffix
         val openPending = detailPendingIntent(info.requestId)
         val allowPending = actionPendingIntent(
             FirewallPromptActionReceiver.ACTION_ALLOW,

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/InteractiveFirewallEngine.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/firewall/InteractiveFirewallEngine.kt
@@ -29,6 +29,7 @@ import ltechnologies.onionphone.onionvpn.core.model.FirewallRuleScope
 import ltechnologies.onionphone.onionvpn.core.model.FirewallVerdict
 import ltechnologies.onionphone.onionvpn.core.model.TunnelPreferences
 import ltechnologies.onionphone.onionvpn.core.vpn.dns.DnsHostnameCache
+import ltechnologies.onionphone.onionvpn.core.vpn.firewall.ApplicationLayerDetector
 import ltechnologies.onionphone.onionvpn.core.vpn.firewall.ConnectionOwnerResolver
 import ltechnologies.onionphone.onionvpn.core.vpn.firewall.IpPacketInfo
 import ltechnologies.onionphone.onionvpn.core.vpn.firewall.IpPacketParser
@@ -171,6 +172,8 @@ class InteractiveFirewallEngine @Inject constructor(
 
         // Resolve app label only on cold ASK/DENY paths (never on cache hits).
         val app = resolveApp(effectiveUid)
+        // DPI only on cold paths — classify DNS/HTTP/HTTPS/… for UX.
+        val dpi = ApplicationLayerDetector.classify(packet, length, info)
         return when (prefs.firewallDefaultAction) {
             FirewallDefaultAction.ALLOW -> {
                 rememberDecision(rk, flowKey, FirewallVerdict.ALLOW)
@@ -184,11 +187,13 @@ class InteractiveFirewallEngine @Inject constructor(
                     info = info,
                     verdict = FirewallVerdict.DENY,
                     scope = FirewallRuleScope.SESSION,
-                    note = "default deny",
+                    note = dpiJournalNote("default deny", dpi),
+                    protocolLabel = dpi.label,
                 )
                 false
             }
-            FirewallDefaultAction.ASK -> enqueuePrompt(effectiveUid, app, info, flowKey, pendingKey, rk)
+            FirewallDefaultAction.ASK ->
+                enqueuePrompt(effectiveUid, app, info, flowKey, pendingKey, rk, dpi)
         }
     }
 
@@ -203,6 +208,7 @@ class InteractiveFirewallEngine @Inject constructor(
         flowKey: Long,
         ruleKey: String,
         decisionKey: Long,
+        dpi: ApplicationLayerDetector.Result,
     ): Boolean {
         val destHost = DnsHostnameCache.lookup(info.dstIp)
         val threat = domainReputation.classify(destHost)
@@ -214,9 +220,10 @@ class InteractiveFirewallEngine @Inject constructor(
             destIp = info.dstIp,
             destPort = info.dstPort,
             protocol = info.protocol,
-            protocolLabel = IpPacketParser.protocolLabel(info.protocol),
+            protocolLabel = dpi.label,
             destHost = destHost,
             threatCategory = threat,
+            dpiDetail = dpi.detail,
         )
         val queued = QueuedPrompt(request, flowKey, app, ruleKey, decisionKey)
         synchronized(queueLock) {
@@ -232,7 +239,8 @@ class InteractiveFirewallEngine @Inject constructor(
                     info = info,
                     verdict = FirewallVerdict.DENY,
                     scope = FirewallRuleScope.SESSION,
-                    note = "queue full — drop (no sticky rule)",
+                    note = dpiJournalNote("queue full — drop (no sticky rule)", dpi),
+                    protocolLabel = dpi.label,
                 )
                 return false
             }
@@ -318,6 +326,7 @@ class InteractiveFirewallEngine @Inject constructor(
             FirewallRuleScope.SESSION -> "until VPN stops"
             FirewallRuleScope.PERMANENT -> "permanent"
         }
+        val dpiNote = answered.request.dpiDetail?.takeIf { it.isNotBlank() }
         appendJournal(
             uid = answered.request.uid,
             app = answered.app,
@@ -328,7 +337,7 @@ class InteractiveFirewallEngine @Inject constructor(
             protocolLabel = answered.request.protocolLabel,
             verdict = verdict,
             ruleScope = ruleScope,
-            note = note,
+            note = if (dpiNote != null) "$note · $dpiNote" else note,
         )
     }
 
@@ -418,6 +427,7 @@ class InteractiveFirewallEngine @Inject constructor(
         verdict: FirewallVerdict,
         scope: FirewallRuleScope,
         note: String,
+        protocolLabel: String = IpPacketParser.protocolLabel(info.protocol),
     ) {
         val destHost = DnsHostnameCache.lookup(info.dstIp)
         appendJournal(
@@ -427,11 +437,16 @@ class InteractiveFirewallEngine @Inject constructor(
             destHost = destHost,
             threatCategory = domainReputation.classify(destHost),
             destPort = info.dstPort,
-            protocolLabel = IpPacketParser.protocolLabel(info.protocol),
+            protocolLabel = protocolLabel,
             verdict = verdict,
             ruleScope = scope,
             note = note,
         )
+    }
+
+    private fun dpiJournalNote(base: String, dpi: ApplicationLayerDetector.Result): String {
+        val detail = dpi.detail?.takeIf { it.isNotBlank() }
+        return if (detail != null) "$base · ${dpi.label}: $detail" else "$base · ${dpi.label}"
     }
 
     private fun appendJournal(

--- a/app/src/main/java/ltechnologies/onionphone/onionvpn/service/TunnelForegroundService.kt
+++ b/app/src/main/java/ltechnologies/onionphone/onionvpn/service/TunnelForegroundService.kt
@@ -36,6 +36,7 @@ import ltechnologies.onionphone.onionvpn.core.model.TunnelSnapshot
 import ltechnologies.onionphone.onionvpn.core.model.ValidationCheck
 import ltechnologies.onionphone.onionvpn.core.model.ValidationStatus
 import ltechnologies.onionphone.onionvpn.core.tor.control.TorControlHealth
+import ltechnologies.onionphone.onionvpn.core.tor.control.model.TorControlStatus
 import ltechnologies.onionphone.onionvpn.core.tor.TorProcessManager
 import ltechnologies.onionphone.onionvpn.core.validation.TunnelValidator
 import ltechnologies.onionphone.onionvpn.core.vpn.OnionVpnService
@@ -74,6 +75,11 @@ class TunnelForegroundService : Service() {
     private var preferences = TunnelPreferences()
     private var runtimePorts: TunnelRuntimePorts? = null
     private var throughputText = ""
+    /** Cumulative Tor `traffic/read` at last throughput sample (all circuits). */
+    private var lastTrafficReadBytes = -1L
+    /** Cumulative Tor `traffic/written` at last throughput sample (all circuits). */
+    private var lastTrafficWriteBytes = -1L
+    private var lastTrafficAtMs = 0L
     private val bandwidthSampler by lazy { TorBandwidthSampler(applicationInfo.uid) }
     private val notifications by lazy { TunnelNotifications(this) }
     private val vpnBridge by lazy { TunnelVpnBridge(this) }
@@ -584,13 +590,17 @@ class TunnelForegroundService : Service() {
         throughputJob?.cancel()
         bandwidthSampler.reset()
         throughputText = ""
+        lastTrafficReadBytes = -1L
+        lastTrafficWriteBytes = -1L
+        lastTrafficAtMs = 0L
         var ticks = 0
         throughputJob = scope.launch {
             while (isActive) {
                 delay(THROUGHPUT_INTERVAL_MS)
                 val phase = _snapshot.value.phase
                 if (phase != TunnelPhase.Connected && phase != TunnelPhase.StartingTor) continue
-                // Prefer live BW events from ControlPort (zero GETINFO cost).
+                // Aggregate bandwidth = process-wide traffic/read|written deltas (all circuits).
+                // BW events are also global; CIRC_BW/STREAM_BW are never used (per-circuit).
                 // Circuit dumps only every ~2 min; lite health every ~10s.
                 ticks++
                 if (ticks % FULL_CONTROL_REFRESH_TICKS == 0) {
@@ -598,16 +608,13 @@ class TunnelForegroundService : Service() {
                 } else if (ticks % LITE_CONTROL_REFRESH_TICKS == 0 || phase == TunnelPhase.StartingTor) {
                     tor.refreshControlHealthLite()
                 }
+                if (phase == TunnelPhase.Connected && tor.controlStatus.value.connected) {
+                    // Dedicated cheap GETINFO so rates track all circuits every tick.
+                    tor.refreshControlTraffic()
+                }
                 val st = tor.controlStatus.value
                 if (phase == TunnelPhase.Connected && st.connected) {
-                    val down = st.lastBwReadPerSec
-                    val up = st.lastBwWritePerSec
-                    throughputText = if (down > 0L || up > 0L) {
-                        "Tor ▼ ${TunnelSnapshotBuilder.formatRate(down)}  ▲ ${TunnelSnapshotBuilder.formatRate(up)}  " +
-                            "circ=${st.builtCircuits}"
-                    } else {
-                        bandwidthSampler.sample().displayText
-                    }
+                    throughputText = formatAggregateThroughput(st)
                 } else if (phase == TunnelPhase.Connected) {
                     throughputText = bandwidthSampler.sample().displayText
                 }
@@ -616,11 +623,56 @@ class TunnelForegroundService : Service() {
         }
     }
 
+    /**
+     * Builds the notification/Status throughput line from **all Tor circuits combined**.
+     *
+     * Priority: cumulative traffic/read|written deltas → control BW event → UID TrafficStats.
+     */
+    private fun formatAggregateThroughput(st: TorControlStatus): String {
+        val now = System.currentTimeMillis()
+        var trafficDown = 0L
+        var trafficUp = 0L
+        if (lastTrafficAtMs > 0L &&
+            lastTrafficReadBytes >= 0L &&
+            st.readBytes >= lastTrafficReadBytes &&
+            st.writeBytes >= lastTrafficWriteBytes
+        ) {
+            val elapsedSec = ((now - lastTrafficAtMs).coerceAtLeast(1L)) / 1000.0
+            trafficDown = ((st.readBytes - lastTrafficReadBytes) / elapsedSec).toLong()
+            trafficUp = ((st.writeBytes - lastTrafficWriteBytes) / elapsedSec).toLong()
+        }
+        lastTrafficReadBytes = st.readBytes
+        lastTrafficWriteBytes = st.writeBytes
+        lastTrafficAtMs = now
+
+        val down: Long
+        val up: Long
+        when {
+            trafficDown > 0L || trafficUp > 0L -> {
+                down = trafficDown
+                up = trafficUp
+            }
+            st.lastBwReadPerSec > 0L || st.lastBwWritePerSec > 0L -> {
+                down = st.lastBwReadPerSec
+                up = st.lastBwWritePerSec
+            }
+            else -> {
+                val sample = bandwidthSampler.sample()
+                return "${sample.displayText}  · ${st.builtCircuits} circuits"
+            }
+        }
+        return "Tor ▼ ${TunnelSnapshotBuilder.formatRate(down)}  ▲ ${TunnelSnapshotBuilder.formatRate(up)}" +
+            "  · ${st.builtCircuits} circuits"
+    }
+
     private fun stopThroughputUpdates() {
         throughputJob?.cancel()
         throughputJob = null
         throughputText = ""
         bandwidthSampler.reset()
+        lastTrafficReadBytes = -1L
+        lastTrafficWriteBytes = -1L
+        lastTrafficAtMs = 0L
     }
 
     private fun acquireBootstrapWakeLock() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="firewall_prompt_channel_name">Firewall prompts</string>
     <string name="firewall_prompt_channel_desc">Connection allow/deny requests with Accept and Deny actions</string>
     <string name="firewall_prompt_notif_title">%1$s wants to connect</string>
-    <!-- %1$s = DPI/app protocol (DNS/HTTP/HTTPS/TCP/…), %2$s = emoji+dest, %3$d = port -->
+    <!-- %1$s = DPI label (DNS/HTTP/HTTPS/SSH/STUN/…), %2$s = emoji+dest, %3$d = port -->
     <string name="firewall_prompt_notif_text">%1$s → %2$s:%3$d</string>
     <string name="firewall_threat_malware">Malware / C2</string>
     <string name="firewall_threat_tracking">Ads / tracking / telemetry</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="firewall_prompt_channel_name">Firewall prompts</string>
     <string name="firewall_prompt_channel_desc">Connection allow/deny requests with Accept and Deny actions</string>
     <string name="firewall_prompt_notif_title">%1$s wants to connect</string>
+    <!-- %1$s = DPI/app protocol (DNS/HTTP/HTTPS/TCP/…), %2$s = emoji+dest, %3$d = port -->
     <string name="firewall_prompt_notif_text">%1$s → %2$s:%3$d</string>
     <string name="firewall_threat_malware">Malware / C2</string>
     <string name="firewall_threat_tracking">Ads / tracking / telemetry</string>

--- a/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/FirewallModels.kt
+++ b/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/FirewallModels.kt
@@ -98,10 +98,18 @@ data class FirewallConnectionInfo(
     val destIp: String,
     val destPort: Int,
     val protocol: Int,
+    /**
+     * Transport or DPI application label shown in UI
+     * (TCP/UDP, or DNS/HTTP/HTTPS/TLS/DoT/QUIC when classified).
+     */
     val protocolLabel: String,
     /** Resolved hostname from DNS snooping, when available. */
     val destHost: String? = null,
     val threatCategory: DomainThreatCategory = DomainThreatCategory.NONE,
+    /**
+     * Optional DPI detail for notifications (DNS QNAME, HTTP Host, TLS SNI, …).
+     */
+    val dpiDetail: String? = null,
     val timestampEpochMs: Long = System.currentTimeMillis(),
 ) {
     /** Prefer hostname for display; fall back to IP. */

--- a/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/TunnelModels.kt
+++ b/core/model/src/main/java/ltechnologies/onionphone/onionvpn/core/model/TunnelModels.kt
@@ -127,7 +127,10 @@ data class TunnelSnapshot(
     val vpnEstablished: Boolean = false,
     val validations: List<ValidationCheck> = emptyList(),
     val lastError: String? = null,
-    /** Live Tor bandwidth text (control GETINFO preferred, UID TrafficStats fallback). */
+    /**
+     * Live Tor bandwidth text — aggregate across **all circuits**
+     * (traffic/read|written deltas, then BW events, then UID TrafficStats).
+     */
     val throughputText: String = "",
     /** Tor control-spec bootstrap 0–100. */
     val torBootstrapProgress: Int = 0,

--- a/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/TorProcessManager.kt
+++ b/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/TorProcessManager.kt
@@ -177,6 +177,11 @@ class TorProcessManager(
     /** Lightweight health poll (no circuit-status dump). */
     fun refreshControlHealthLite() = control.refreshHealthLite()
 
+    /**
+     * Process-wide `traffic/read|written` only — for aggregate bandwidth across all circuits.
+     */
+    fun refreshControlTraffic() = control.refreshTraffic()
+
     /** Live SETCONF bridges from multiline preference text. */
     fun setBridgesLive(bridgeText: String): Result<Unit> {
         if (!control.isConnected) return Result.failure(IOException("control not connected"))

--- a/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/control/TorControlClient.kt
+++ b/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/control/TorControlClient.kt
@@ -219,6 +219,24 @@ class TorControlClient {
     }
 
     /**
+     * Traffic counters only (`traffic/read` + `traffic/written`) — process-wide totals
+     * across **all** circuits. Used by the aggregate bandwidth indicator.
+     */
+    fun refreshTraffic() {
+        if (!transport.isOpen) return
+        runCatching {
+            val traffic = ops.getInfoMany(*TorControlCatalog.HEALTH_GETINFO_TRAFFIC.toTypedArray())
+            val read = traffic["traffic/read"]?.toLongOrNull() ?: return
+            val write = traffic["traffic/written"]?.toLongOrNull() ?: return
+            _status.update {
+                it.copy(readBytes = read, writeBytes = write)
+            }
+        }.onFailure { err ->
+            Timber.d(err, "Tor traffic GETINFO failed")
+        }
+    }
+
+    /**
      * Cheap health poll for network recovery / periodic keep-alive.
      */
     fun refreshHealthLite() {

--- a/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/control/model/TorControlModels.kt
+++ b/core/tor/src/main/java/ltechnologies/onionphone/onionvpn/core/tor/control/model/TorControlModels.kt
@@ -49,13 +49,19 @@ data class TorControlStatus(
     val lastCircEvent: String = "",
     /** Last STREAM status line for UI debug. */
     val lastStreamEvent: String = "",
-    /** GETINFO traffic/read (bytes). */
+    /** GETINFO traffic/read — cumulative bytes read by Tor (**all circuits**). */
     val readBytes: Long = 0L,
-    /** GETINFO traffic/written (bytes). */
+    /** GETINFO traffic/written — cumulative bytes written by Tor (**all circuits**). */
     val writeBytes: Long = 0L,
-    /** Last BW event read bytes/sec (control-spec). */
+    /**
+     * Last control-spec `BW` event read bytes/sec.
+     * Process-wide (sum of all OR/circuit traffic), not a single circuit.
+     */
     val lastBwReadPerSec: Long = 0L,
-    /** Last BW event written bytes/sec (control-spec). */
+    /**
+     * Last control-spec `BW` event written bytes/sec.
+     * Process-wide (sum of all OR/circuit traffic), not a single circuit.
+     */
     val lastBwWritePerSec: Long = 0L,
     /** Last control-plane error message, if any. */
     val lastError: String? = null,

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/firewall/ApplicationLayerDetector.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/firewall/ApplicationLayerDetector.kt
@@ -5,31 +5,66 @@ import java.nio.charset.StandardCharsets
 import java.util.Locale
 
 /**
- * Lightweight DPI for firewall UX: classify TCP/UDP flows as DNS / HTTP / HTTPS / TLS / …
+ * Lightweight DPI for firewall UX: classify TCP/UDP into application protocols.
  *
  * Hot path must stay cheap — call only on cold ASK/DENY/journal paths, never on every packet.
  *
  * Detection order:
- * 1. Payload signatures (DNS wire, HTTP methods, TLS ClientHello / record, QUIC)
+ * 1. Payload signatures (DNS, HTTP/2, HTTP, TLS/DTLS, QUIC, SSH, STUN, …)
  * 2. Well-known port heuristics when the first packet has no payload (TCP SYN)
  */
 object ApplicationLayerDetector {
 
     data class Result(
-        /** Short label for notifications (DNS, HTTP, HTTPS, TLS, DoT, QUIC, TCP, UDP). */
+        /** Short label for notifications. */
         val label: String,
-        /** Optional detail: QNAME, Host, SNI, HTTP method+path. */
+        /** Optional detail: QNAME, Host, SNI, method, banner snippet. */
         val detail: String? = null,
         val kind: Kind = Kind.UNKNOWN,
     )
 
     enum class Kind {
         DNS,
-        HTTP,
-        HTTPS,
-        TLS,
+        MDNS,
+        LLMNR,
+        DOH,
         DOT,
+        HTTP,
+        HTTP2,
+        HTTPS,
+        WEBSOCKET,
+        TLS,
+        DTLS,
         QUIC,
+        SSH,
+        FTP,
+        SMTP,
+        SMTPS,
+        IMAP,
+        IMAPS,
+        POP3,
+        POP3S,
+        SIP,
+        RTSP,
+        MQTT,
+        STUN,
+        WIREGUARD,
+        OPENVPN,
+        RDP,
+        VNC,
+        REDIS,
+        MYSQL,
+        POSTGRES,
+        MONGODB,
+        BITTORRENT,
+        SOCKS,
+        NTP,
+        DHCP,
+        TFTP,
+        SSDP,
+        XMPP,
+        IRC,
+        GIT,
         UNKNOWN,
     }
 
@@ -49,103 +84,334 @@ object ApplicationLayerDetector {
         len: Int,
         info: IpPacketInfo,
     ): Result? {
+        // --- DNS family (UDP/TCP) ---
         if (looksLikeDns(packet, offset, len, info)) {
             val parsed = DnsPacketParser.parse(packet, offset, len)
             val qname = parsed?.qname?.takeIf { it.isNotBlank() }
+            val kind = when (info.dstPort) {
+                5353, 5355 -> if (info.dstPort == 5353) Kind.MDNS else Kind.LLMNR
+                else -> Kind.DNS
+            }
+            val label = when (kind) {
+                Kind.MDNS -> "mDNS"
+                Kind.LLMNR -> "LLMNR"
+                else -> "DNS"
+            }
             val detail = when {
-                qname != null && parsed?.isResponse == true -> "DNS response $qname"
-                qname != null -> "DNS query $qname"
+                qname != null && parsed?.isResponse == true -> "$label response $qname"
+                qname != null -> "$label query $qname"
                 else -> null
             }
-            return Result(label = "DNS", detail = detail, kind = Kind.DNS)
+            return Result(label = label, detail = detail, kind = kind)
         }
 
-        if (info.isTcp && looksLikeHttp(packet, offset, len)) {
-            val preview = httpPreview(packet, offset, len)
-            return Result(label = "HTTP", detail = preview, kind = Kind.HTTP)
+        // --- Cleartext ASCII / framed app protocols ---
+        if (info.isTcp && looksLikeHttp2Preface(packet, offset, len)) {
+            return Result(label = "HTTP/2", detail = "PRI preface", kind = Kind.HTTP2)
+        }
+
+        if ((info.isTcp || info.isUdp) && looksLikeHttp(packet, offset, len)) {
+            return classifyHttpFamily(packet, offset, len, info)
+        }
+
+        if (info.isTcp && looksLikeSsh(packet, offset, len)) {
+            val banner = asciiPrefix(packet, offset, len, 48)
+            return Result(label = "SSH", detail = banner, kind = Kind.SSH)
+        }
+
+        if (info.isTcp && looksLikeFtp(packet, offset, len)) {
+            return Result(label = "FTP", detail = asciiPrefix(packet, offset, len, 40), kind = Kind.FTP)
+        }
+
+        if (info.isTcp && looksLikeSmtp(packet, offset, len)) {
+            return Result(label = "SMTP", detail = asciiPrefix(packet, offset, len, 40), kind = Kind.SMTP)
+        }
+
+        if (info.isTcp && looksLikeImap(packet, offset, len)) {
+            return Result(label = "IMAP", detail = asciiPrefix(packet, offset, len, 40), kind = Kind.IMAP)
+        }
+
+        if (info.isTcp && looksLikePop3(packet, offset, len)) {
+            return Result(label = "POP3", detail = asciiPrefix(packet, offset, len, 40), kind = Kind.POP3)
+        }
+
+        if (looksLikeSip(packet, offset, len)) {
+            return Result(label = "SIP", detail = asciiPrefix(packet, offset, len, 48), kind = Kind.SIP)
+        }
+
+        if (info.isTcp && looksLikeRtsp(packet, offset, len)) {
+            return Result(label = "RTSP", detail = asciiPrefix(packet, offset, len, 48), kind = Kind.RTSP)
+        }
+
+        if (info.isUdp && looksLikeSsdp(packet, offset, len)) {
+            return Result(label = "SSDP", detail = "M-SEARCH", kind = Kind.SSDP)
+        }
+
+        if (info.isTcp && looksLikeXmpp(packet, offset, len)) {
+            return Result(label = "XMPP", detail = asciiPrefix(packet, offset, len, 48), kind = Kind.XMPP)
+        }
+
+        if (info.isTcp && looksLikeIrc(packet, offset, len)) {
+            return Result(label = "IRC", detail = asciiPrefix(packet, offset, len, 40), kind = Kind.IRC)
+        }
+
+        if (info.isTcp && looksLikeRedis(packet, offset, len)) {
+            return Result(label = "Redis", detail = asciiPrefix(packet, offset, len, 32), kind = Kind.REDIS)
+        }
+
+        if (info.isTcp && looksLikeBitTorrent(packet, offset, len)) {
+            return Result(label = "BitTorrent", detail = "handshake", kind = Kind.BITTORRENT)
+        }
+
+        if (info.isTcp && looksLikeSocks(packet, offset, len)) {
+            val ver = packet[offset].toInt() and 0xff
+            return Result(label = "SOCKS$ver", detail = null, kind = Kind.SOCKS)
+        }
+
+        if (info.isTcp && looksLikeRdp(packet, offset, len)) {
+            return Result(label = "RDP", detail = "TPKT/X.224", kind = Kind.RDP)
+        }
+
+        if (info.isTcp && looksLikeVnc(packet, offset, len)) {
+            return Result(label = "VNC", detail = asciiPrefix(packet, offset, len, 16), kind = Kind.VNC)
+        }
+
+        if (info.isTcp && looksLikePostgres(packet, offset, len)) {
+            return Result(label = "PostgreSQL", detail = "startup", kind = Kind.POSTGRES)
+        }
+
+        if (info.isTcp && looksLikeMysql(packet, offset, len)) {
+            return Result(label = "MySQL", detail = "greeting/handshake", kind = Kind.MYSQL)
+        }
+
+        if (info.isTcp && looksLikeMqtt(packet, offset, len)) {
+            return Result(label = "MQTT", detail = "CONNECT", kind = Kind.MQTT)
+        }
+
+        if (info.isUdp && looksLikeStun(packet, offset, len)) {
+            return Result(label = "STUN", detail = "UDP/${info.dstPort}", kind = Kind.STUN)
+        }
+
+        if (info.isUdp && looksLikeWireGuard(packet, offset, len)) {
+            return Result(label = "WireGuard", detail = "UDP/${info.dstPort}", kind = Kind.WIREGUARD)
+        }
+
+        if (info.isUdp && looksLikeOpenVpn(packet, offset, len)) {
+            return Result(label = "OpenVPN", detail = "UDP/${info.dstPort}", kind = Kind.OPENVPN)
+        }
+
+        if (info.isUdp && looksLikeNtp(packet, offset, len, info)) {
+            return Result(label = "NTP", detail = null, kind = Kind.NTP)
+        }
+
+        if (info.isUdp && looksLikeDhcp(packet, offset, len, info)) {
+            return Result(label = "DHCP", detail = null, kind = Kind.DHCP)
+        }
+
+        if (info.isUdp && looksLikeTftp(packet, offset, len, info)) {
+            return Result(label = "TFTP", detail = null, kind = Kind.TFTP)
+        }
+
+        // --- TLS / DTLS / QUIC (after cleartext checks) ---
+        if (info.isUdp && looksLikeDtls(packet, offset, len)) {
+            return Result(label = "DTLS", detail = "UDP/${info.dstPort}", kind = Kind.DTLS)
         }
 
         if (info.isTcp && looksLikeTls(packet, offset, len)) {
-            val sni = extractTlsSni(packet, offset, len)
-            val https = info.dstPort == 443 || info.dstPort == 8443
-            return Result(
-                label = if (https) "HTTPS" else "TLS",
-                detail = sni?.let { "SNI $it" },
-                kind = if (https) Kind.HTTPS else Kind.TLS,
-            )
+            return classifyTls(packet, offset, len, info)
         }
 
-        if (info.isUdp && looksLikeQuic(packet, offset, len, info)) {
-            return Result(label = "QUIC", detail = "UDP/${info.dstPort}", kind = Kind.QUIC)
+        if (info.isUdp && looksLikeQuic(packet, offset, len)) {
+            val http3 = info.dstPort == 443 || info.dstPort == 80
+            return Result(
+                label = if (http3) "HTTP/3" else "QUIC",
+                detail = "UDP/${info.dstPort}",
+                kind = Kind.QUIC,
+            )
         }
 
         return null
     }
 
-    private fun portHeuristic(info: IpPacketInfo): Result = when {
-        info.dstPort == 53 || info.srcPort == 53 ->
-            Result(label = "DNS", detail = null, kind = Kind.DNS)
-        info.dstPort == 853 ->
-            Result(label = "DoT", detail = "TLS DNS :853", kind = Kind.DOT)
-        info.isTcp && (info.dstPort == 80 || info.dstPort == 8080 || info.dstPort == 8000) ->
-            Result(label = "HTTP", detail = "port ${info.dstPort}", kind = Kind.HTTP)
-        info.isTcp && (info.dstPort == 443 || info.dstPort == 8443) ->
-            Result(label = "HTTPS", detail = "port ${info.dstPort}", kind = Kind.HTTPS)
-        info.isUdp && (info.dstPort == 443 || info.dstPort == 80) ->
-            Result(label = "QUIC", detail = "port ${info.dstPort}", kind = Kind.QUIC)
-        info.isTcp ->
-            Result(label = "TCP", detail = null, kind = Kind.UNKNOWN)
-        info.isUdp ->
-            Result(label = "UDP", detail = null, kind = Kind.UNKNOWN)
-        else ->
-            Result(
-                label = IpPacketParser.protocolLabel(info.protocol),
-                detail = null,
-                kind = Kind.UNKNOWN,
-            )
+    private fun classifyHttpFamily(
+        packet: ByteArray,
+        offset: Int,
+        len: Int,
+        info: IpPacketInfo,
+    ): Result {
+        val text = String(packet, offset, minOf(len, 512), StandardCharsets.US_ASCII)
+        val preview = httpPreview(text)
+        val lower = text.lowercase(Locale.US)
+        val websocket = lower.contains("upgrade: websocket") ||
+            lower.contains("\nsec-websocket-key:")
+        val doh = lower.contains("/dns-query") ||
+            lower.contains("/.well-known/dns-query") ||
+            lower.contains("application/dns-message") ||
+            lower.contains("application/dns-json")
+        return when {
+            websocket -> Result(label = "WebSocket", detail = preview, kind = Kind.WEBSOCKET)
+            doh -> Result(label = "DoH", detail = preview, kind = Kind.DOH)
+            else -> Result(label = "HTTP", detail = preview, kind = Kind.HTTP)
+        }
     }
 
-    /**
-     * DNS wire format: 12-byte header, QDCOUNT ≥ 1 for queries, sane flag bits.
-     * Port 53 strongly preferred; also accept clear DNS shape on other ports (DoH-less plain DNS).
-     */
+    private fun classifyTls(
+        packet: ByteArray,
+        offset: Int,
+        len: Int,
+        info: IpPacketInfo,
+    ): Result {
+        val sni = extractTlsSni(packet, offset, len)
+        val detail = sni?.let { "SNI $it" }
+        return when (info.dstPort) {
+            443, 8443 -> Result(label = "HTTPS", detail = detail, kind = Kind.HTTPS)
+            853 -> Result(label = "DoT", detail = detail ?: "TLS DNS :853", kind = Kind.DOT)
+            465, 587 -> Result(label = "SMTPS", detail = detail, kind = Kind.SMTPS)
+            993 -> Result(label = "IMAPS", detail = detail, kind = Kind.IMAPS)
+            995 -> Result(label = "POP3S", detail = detail, kind = Kind.POP3S)
+            5223, 5222 -> Result(label = "XMPP", detail = detail ?: "TLS", kind = Kind.XMPP)
+            8883 -> Result(label = "MQTT", detail = detail ?: "TLS :8883", kind = Kind.MQTT)
+            636 -> Result(label = "TLS", detail = detail ?: "LDAPS :636", kind = Kind.TLS)
+            else -> Result(label = "TLS", detail = detail, kind = Kind.TLS)
+        }
+    }
+
+    private fun portHeuristic(info: IpPacketInfo): Result {
+        val p = info.dstPort
+        return when {
+            p == 53 || info.srcPort == 53 ->
+                Result(label = "DNS", detail = null, kind = Kind.DNS)
+            p == 5353 ->
+                Result(label = "mDNS", detail = "port 5353", kind = Kind.MDNS)
+            p == 5355 ->
+                Result(label = "LLMNR", detail = "port 5355", kind = Kind.LLMNR)
+            p == 853 ->
+                Result(label = "DoT", detail = "TLS DNS :853", kind = Kind.DOT)
+            info.isTcp && p in HTTP_PORTS ->
+                Result(label = "HTTP", detail = "port $p", kind = Kind.HTTP)
+            info.isTcp && p in HTTPS_PORTS ->
+                Result(label = "HTTPS", detail = "port $p", kind = Kind.HTTPS)
+            info.isUdp && (p == 443 || p == 80) ->
+                Result(label = "HTTP/3", detail = "port $p", kind = Kind.QUIC)
+            info.isTcp && p == 22 ->
+                Result(label = "SSH", detail = "port 22", kind = Kind.SSH)
+            info.isTcp && (p == 21 || p == 20) ->
+                Result(label = "FTP", detail = "port $p", kind = Kind.FTP)
+            info.isTcp && p == 25 ->
+                Result(label = "SMTP", detail = "port 25", kind = Kind.SMTP)
+            info.isTcp && (p == 465 || p == 587) ->
+                Result(label = "SMTPS", detail = "port $p", kind = Kind.SMTPS)
+            info.isTcp && p == 143 ->
+                Result(label = "IMAP", detail = "port 143", kind = Kind.IMAP)
+            info.isTcp && p == 993 ->
+                Result(label = "IMAPS", detail = "port 993", kind = Kind.IMAPS)
+            info.isTcp && p == 110 ->
+                Result(label = "POP3", detail = "port 110", kind = Kind.POP3)
+            info.isTcp && p == 995 ->
+                Result(label = "POP3S", detail = "port 995", kind = Kind.POP3S)
+            (info.isTcp || info.isUdp) && (p == 5060 || p == 5061) ->
+                Result(
+                    label = if (p == 5061) "SIP/TLS" else "SIP",
+                    detail = "port $p",
+                    kind = Kind.SIP,
+                )
+            info.isTcp && p == 554 ->
+                Result(label = "RTSP", detail = "port 554", kind = Kind.RTSP)
+            info.isTcp && (p == 1883 || p == 8883) ->
+                Result(label = "MQTT", detail = "port $p", kind = Kind.MQTT)
+            (info.isUdp || info.isTcp) && (p == 3478 || p == 5349) ->
+                Result(label = "STUN", detail = "port $p", kind = Kind.STUN)
+            info.isUdp && p in 51820..51830 ->
+                Result(label = "WireGuard", detail = "port $p", kind = Kind.WIREGUARD)
+            (info.isUdp || info.isTcp) && p == 1194 ->
+                Result(label = "OpenVPN", detail = "port 1194", kind = Kind.OPENVPN)
+            info.isTcp && p == 3389 ->
+                Result(label = "RDP", detail = "port 3389", kind = Kind.RDP)
+            info.isTcp && (p == 5900 || p in 5900..5910) ->
+                Result(label = "VNC", detail = "port $p", kind = Kind.VNC)
+            info.isTcp && p == 6379 ->
+                Result(label = "Redis", detail = "port 6379", kind = Kind.REDIS)
+            info.isTcp && p == 3306 ->
+                Result(label = "MySQL", detail = "port 3306", kind = Kind.MYSQL)
+            info.isTcp && p == 5432 ->
+                Result(label = "PostgreSQL", detail = "port 5432", kind = Kind.POSTGRES)
+            info.isTcp && p == 27017 ->
+                Result(label = "MongoDB", detail = "port 27017", kind = Kind.MONGODB)
+            info.isTcp && (p == 1080 || p == 9050 || p == 9150) ->
+                Result(label = "SOCKS", detail = "port $p", kind = Kind.SOCKS)
+            info.isUdp && p == 123 ->
+                Result(label = "NTP", detail = "port 123", kind = Kind.NTP)
+            info.isUdp && (p == 67 || p == 68) ->
+                Result(label = "DHCP", detail = "port $p", kind = Kind.DHCP)
+            info.isUdp && p == 69 ->
+                Result(label = "TFTP", detail = "port 69", kind = Kind.TFTP)
+            info.isUdp && p == 1900 ->
+                Result(label = "SSDP", detail = "port 1900", kind = Kind.SSDP)
+            info.isTcp && (p == 5222 || p == 5223) ->
+                Result(label = "XMPP", detail = "port $p", kind = Kind.XMPP)
+            info.isTcp && (p == 6667 || p == 6697) ->
+                Result(label = "IRC", detail = "port $p", kind = Kind.IRC)
+            info.isTcp && p == 9418 ->
+                Result(label = "Git", detail = "port 9418", kind = Kind.GIT)
+            info.isTcp && (p == 6881 || p in 6881..6889) ->
+                Result(label = "BitTorrent", detail = "port $p", kind = Kind.BITTORRENT)
+            info.isTcp ->
+                Result(label = "TCP", detail = null, kind = Kind.UNKNOWN)
+            info.isUdp ->
+                Result(label = "UDP", detail = null, kind = Kind.UNKNOWN)
+            else ->
+                Result(
+                    label = IpPacketParser.protocolLabel(info.protocol),
+                    detail = null,
+                    kind = Kind.UNKNOWN,
+                )
+        }
+    }
+
+    // --- signature helpers ---
+
     private fun looksLikeDns(packet: ByteArray, offset: Int, len: Int, info: IpPacketInfo): Boolean {
         if (len < 12) return false
-        val onDnsPort = info.dstPort == 53 || info.srcPort == 53
-        val flags = ((packet[offset + 2].toInt() and 0xff) shl 8) or
-            (packet[offset + 3].toInt() and 0xff)
+        val onDnsPort = info.dstPort == 53 || info.srcPort == 53 ||
+            info.dstPort == 5353 || info.dstPort == 5355
+        // DNS-over-TCP starts with 2-byte length prefix.
+        var off = offset
+        var dnsLen = len
+        if (info.isTcp && len >= 14) {
+            val prefixed = ((packet[offset].toInt() and 0xff) shl 8) or
+                (packet[offset + 1].toInt() and 0xff)
+            if (prefixed in 12..len - 2 && prefixed + 2 <= len) {
+                off = offset + 2
+                dnsLen = prefixed
+            }
+        }
+        val flags = ((packet[off + 2].toInt() and 0xff) shl 8) or
+            (packet[off + 3].toInt() and 0xff)
         val opcode = (flags ushr 11) and 0x0f
         if (opcode > 2) return false
-        val qd = ((packet[offset + 4].toInt() and 0xff) shl 8) or
-            (packet[offset + 5].toInt() and 0xff)
-        val an = ((packet[offset + 6].toInt() and 0xff) shl 8) or
-            (packet[offset + 7].toInt() and 0xff)
-        val ns = ((packet[offset + 8].toInt() and 0xff) shl 8) or
-            (packet[offset + 9].toInt() and 0xff)
-        val ar = ((packet[offset + 10].toInt() and 0xff) shl 8) or
-            (packet[offset + 11].toInt() and 0xff)
+        val qd = u16(packet, off + 4)
+        val an = u16(packet, off + 6)
+        val ns = u16(packet, off + 8)
+        val ar = u16(packet, off + 10)
         if (qd > 16 || an > 64 || ns > 64 || ar > 64) return false
         if (qd == 0 && an == 0) return false
-        val parsed = DnsPacketParser.parse(packet, offset, len)
+        val parsed = DnsPacketParser.parse(packet, off, dnsLen)
         if (parsed?.qname != null) return true
         return onDnsPort && qd >= 1
     }
 
+    private fun looksLikeHttp2Preface(packet: ByteArray, offset: Int, len: Int): Boolean =
+        startsWithAscii(packet, offset, len, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+
     private fun looksLikeHttp(packet: ByteArray, offset: Int, len: Int): Boolean {
         if (len < 4) return false
-        val methods = arrayOf(
-            "GET ", "POST ", "HEAD ", "PUT ", "DELETE ", "OPTIONS ", "CONNECT ", "PATCH ",
-            "HTTP/1.",
-        )
-        for (m in methods) {
+        for (m in HTTP_METHODS) {
             if (startsWithAscii(packet, offset, len, m)) return true
         }
         return false
     }
 
-    private fun httpPreview(packet: ByteArray, offset: Int, len: Int): String? {
-        val max = minOf(len, 256)
-        val text = String(packet, offset, max, StandardCharsets.US_ASCII)
+    private fun httpPreview(text: String): String? {
         val firstLine = text.lineSequence().firstOrNull()?.trim().orEmpty()
         if (firstLine.isEmpty()) return null
         val host = Regex("""(?im)^Host:\s*(\S+)""")
@@ -154,7 +420,6 @@ object ApplicationLayerDetector {
         return if (host != null) "$line · Host $host" else line
     }
 
-    /** TLS record: content-type 0x14–0x17, version 0x03 0x01–0x04. */
     private fun looksLikeTls(packet: ByteArray, offset: Int, len: Int): Boolean {
         if (len < 5) return false
         val type = packet[offset].toInt() and 0xff
@@ -164,22 +429,24 @@ object ApplicationLayerDetector {
         return major == 0x03 && minor <= 0x04
     }
 
-    /**
-     * Best-effort SNI from a TLS ClientHello (handshake type 0x01).
-     * Returns null if truncated / encrypted / not a ClientHello.
-     */
+    private fun looksLikeDtls(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (len < 13) return false
+        val type = packet[offset].toInt() and 0xff
+        if (type !in 0x14..0x17) return false
+        val major = packet[offset + 1].toInt() and 0xff
+        val minor = packet[offset + 2].toInt() and 0xff
+        // DTLS 1.0 = FE FF, 1.2 = FE FD, 1.3 = FE FC
+        return major == 0xFE && minor in 0xFC..0xFF
+    }
+
     fun extractTlsSni(packet: ByteArray, offset: Int, len: Int): String? {
         if (len < 9) return null
-        if ((packet[offset].toInt() and 0xff) != 0x16) return null // handshake record
-        val recordLen = ((packet[offset + 3].toInt() and 0xff) shl 8) or
-            (packet[offset + 4].toInt() and 0xff)
-        if (recordLen < 4 || 5 + recordLen > len) {
-            // Allow truncated first segment — parse what we have.
-        }
+        if ((packet[offset].toInt() and 0xff) != 0x16) return null
+        val recordLen = u16(packet, offset + 3)
         var p = offset + 5
         val end = offset + minOf(len, 5 + maxOf(recordLen, 0))
         if (p >= end) return null
-        if ((packet[p].toInt() and 0xff) != 0x01) return null // client_hello
+        if ((packet[p].toInt() and 0xff) != 0x01) return null
         p += 1
         if (p + 3 > end) return null
         val helloLen = ((packet[p].toInt() and 0xff) shl 16) or
@@ -188,33 +455,32 @@ object ApplicationLayerDetector {
         p += 3
         val helloEnd = minOf(end, p + helloLen)
         if (p + 2 + 32 + 1 > helloEnd) return null
-        p += 2 // client_version
-        p += 32 // random
+        p += 2
+        p += 32
         if (p >= helloEnd) return null
         val sessionLen = packet[p].toInt() and 0xff
         p += 1 + sessionLen
         if (p + 2 > helloEnd) return null
-        val cipherLen = ((packet[p].toInt() and 0xff) shl 8) or (packet[p + 1].toInt() and 0xff)
+        val cipherLen = u16(packet, p)
         p += 2 + cipherLen
         if (p + 1 > helloEnd) return null
         val compLen = packet[p].toInt() and 0xff
         p += 1 + compLen
         if (p + 2 > helloEnd) return null
-        val extLen = ((packet[p].toInt() and 0xff) shl 8) or (packet[p + 1].toInt() and 0xff)
+        val extLen = u16(packet, p)
         p += 2
         val extEnd = minOf(helloEnd, p + extLen)
         while (p + 4 <= extEnd) {
-            val type = ((packet[p].toInt() and 0xff) shl 8) or (packet[p + 1].toInt() and 0xff)
-            val elen = ((packet[p + 2].toInt() and 0xff) shl 8) or (packet[p + 3].toInt() and 0xff)
+            val type = u16(packet, p)
+            val elen = u16(packet, p + 2)
             p += 4
             if (p + elen > extEnd) break
-            if (type == 0x0000 && elen >= 5) { // server_name
-                // list_len(2) name_type(1) name_len(2) name
+            if (type == 0x0000 && elen >= 5) {
                 var q = p + 2
                 if (q + 3 > p + elen) break
                 val nameType = packet[q].toInt() and 0xff
                 q += 1
-                val nameLen = ((packet[q].toInt() and 0xff) shl 8) or (packet[q + 1].toInt() and 0xff)
+                val nameLen = u16(packet, q)
                 q += 2
                 if (nameType == 0 && q + nameLen <= p + elen && nameLen in 1..253) {
                     return String(packet, q, nameLen, StandardCharsets.US_ASCII)
@@ -226,12 +492,275 @@ object ApplicationLayerDetector {
         return null
     }
 
-    /** QUIC long-header packets set the high bit of the first byte (RFC 9000). */
-    private fun looksLikeQuic(packet: ByteArray, offset: Int, len: Int, info: IpPacketInfo): Boolean {
+    private fun looksLikeQuic(packet: ByteArray, offset: Int, len: Int): Boolean {
         if (len < 5) return false
-        if (info.dstPort != 443 && info.dstPort != 80) return false
         val b0 = packet[offset].toInt() and 0xff
-        return (b0 and 0x80) != 0
+        // Long header (bit7=1) or short header with fixed bit (bit6=1) — RFC 9000.
+        return (b0 and 0x80) != 0 || (b0 and 0x40) != 0
+    }
+
+    private fun looksLikeSsh(packet: ByteArray, offset: Int, len: Int): Boolean =
+        startsWithAscii(packet, offset, len, "SSH-")
+
+    private fun looksLikeFtp(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (startsWithAscii(packet, offset, len, "USER ") ||
+            startsWithAscii(packet, offset, len, "PASS ") ||
+            startsWithAscii(packet, offset, len, "QUIT")
+        ) {
+            return true
+        }
+        // Server greeting "220 "
+        return len >= 4 &&
+            (packet[offset].toInt() and 0xff) == '2'.code &&
+            (packet[offset + 1].toInt() and 0xff) == '2'.code &&
+            (packet[offset + 2].toInt() and 0xff) == '0'.code &&
+            (packet[offset + 3].toInt() and 0xff) == ' '.code
+    }
+
+    private fun looksLikeSmtp(packet: ByteArray, offset: Int, len: Int): Boolean {
+        for (p in SMTP_PREFIXES) {
+            if (startsWithAscii(packet, offset, len, p)) return true
+        }
+        return len >= 4 &&
+            (packet[offset].toInt() and 0xff) == '2'.code &&
+            (packet[offset + 1].toInt() and 0xff) == '2'.code &&
+            (packet[offset + 2].toInt() and 0xff) == '0'.code &&
+            (packet[offset + 3].toInt() and 0xff) == ' '.code &&
+            asciiContains(packet, offset, minOf(len, 64), "ESMTP")
+    }
+
+    private fun looksLikeImap(packet: ByteArray, offset: Int, len: Int): Boolean =
+        startsWithAscii(packet, offset, len, "* OK") ||
+            startsWithAscii(packet, offset, len, "* PREAUTH") ||
+            asciiStartsWithTagCommand(packet, offset, len, "LOGIN") ||
+            asciiStartsWithTagCommand(packet, offset, len, "AUTHENTICATE")
+
+    private fun looksLikePop3(packet: ByteArray, offset: Int, len: Int): Boolean =
+        startsWithAscii(packet, offset, len, "+OK") ||
+            startsWithAscii(packet, offset, len, "-ERR") ||
+            startsWithAscii(packet, offset, len, "USER ") ||
+            startsWithAscii(packet, offset, len, "PASS ") ||
+            startsWithAscii(packet, offset, len, "STAT") ||
+            startsWithAscii(packet, offset, len, "RETR ")
+
+    private fun looksLikeSip(packet: ByteArray, offset: Int, len: Int): Boolean {
+        for (p in SIP_PREFIXES) {
+            if (startsWithAscii(packet, offset, len, p)) return true
+        }
+        return false
+    }
+
+    private fun looksLikeRtsp(packet: ByteArray, offset: Int, len: Int): Boolean {
+        for (p in RTSP_PREFIXES) {
+            if (startsWithAscii(packet, offset, len, p)) return true
+        }
+        return false
+    }
+
+    private fun looksLikeSsdp(packet: ByteArray, offset: Int, len: Int): Boolean =
+        startsWithAscii(packet, offset, len, "M-SEARCH ") ||
+            startsWithAscii(packet, offset, len, "NOTIFY ")
+
+    private fun looksLikeXmpp(packet: ByteArray, offset: Int, len: Int): Boolean =
+        startsWithAscii(packet, offset, len, "<?xml") ||
+            startsWithAscii(packet, offset, len, "<stream:stream") ||
+            startsWithAscii(packet, offset, len, "<stream:")
+
+    private fun looksLikeIrc(packet: ByteArray, offset: Int, len: Int): Boolean {
+        for (p in IRC_PREFIXES) {
+            if (startsWithAscii(packet, offset, len, p)) return true
+        }
+        return false
+    }
+
+    private fun looksLikeRedis(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (len < 3) return false
+        val c0 = packet[offset].toInt() and 0xff
+        // RESP: *n\r\n  or +OK / -ERR / $ / :
+        if (c0 == '*'.code || c0 == '+'.code || c0 == '-'.code ||
+            c0 == '$'.code || c0 == ':'.code
+        ) {
+            // Prefer clear Redis verbs in the first chunk.
+            return asciiContains(packet, offset, minOf(len, 64), "\r\n") &&
+                (
+                    asciiContains(packet, offset, minOf(len, 64), "PING") ||
+                        asciiContains(packet, offset, minOf(len, 64), "AUTH") ||
+                        asciiContains(packet, offset, minOf(len, 64), "INFO") ||
+                        asciiContains(packet, offset, minOf(len, 64), "HELLO") ||
+                        c0 == '*'.code
+                    )
+        }
+        return false
+    }
+
+    private fun looksLikeBitTorrent(packet: ByteArray, offset: Int, len: Int): Boolean =
+        len >= 20 &&
+            (packet[offset].toInt() and 0xff) == 19 &&
+            startsWithAscii(packet, offset + 1, len - 1, "BitTorrent protocol")
+
+    private fun looksLikeSocks(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (len < 2) return false
+        val ver = packet[offset].toInt() and 0xff
+        return when (ver) {
+            5 -> {
+                // VER NMETHODS METHODS…
+                val n = packet[offset + 1].toInt() and 0xff
+                n in 1..16 && len >= 2 + n
+            }
+            4 -> len >= 8 && (packet[offset + 1].toInt() and 0xff) in 1..2
+            else -> false
+        }
+    }
+
+    private fun looksLikeRdp(packet: ByteArray, offset: Int, len: Int): Boolean {
+        // TPKT version 3 + X.224 Connection Request (CR length / type 0xE0)
+        if (len < 7) return false
+        if ((packet[offset].toInt() and 0xff) != 3) return false
+        if ((packet[offset + 1].toInt() and 0xff) != 0) return false
+        val tpktLen = u16(packet, offset + 2)
+        if (tpktLen < 7 || tpktLen > len + 64) return false
+        val li = packet[offset + 4].toInt() and 0xff
+        val code = packet[offset + 5].toInt() and 0xff
+        return li >= 6 && (code == 0xE0 || code == 0xD0)
+    }
+
+    private fun looksLikeVnc(packet: ByteArray, offset: Int, len: Int): Boolean =
+        startsWithAscii(packet, offset, len, "RFB ")
+
+    private fun looksLikePostgres(packet: ByteArray, offset: Int, len: Int): Boolean {
+        // StartupMessage: int32 len + int32 protocol (3<<16|0) = 196608
+        if (len < 8) return false
+        val msgLen = ((packet[offset].toInt() and 0xff) shl 24) or
+            ((packet[offset + 1].toInt() and 0xff) shl 16) or
+            ((packet[offset + 2].toInt() and 0xff) shl 8) or
+            (packet[offset + 3].toInt() and 0xff)
+        if (msgLen < 8 || msgLen > 10_000) return false
+        val proto = ((packet[offset + 4].toInt() and 0xff) shl 24) or
+            ((packet[offset + 5].toInt() and 0xff) shl 16) or
+            ((packet[offset + 6].toInt() and 0xff) shl 8) or
+            (packet[offset + 7].toInt() and 0xff)
+        return proto == 196608 || proto == 80877103 // SSLRequest
+    }
+
+    private fun looksLikeMysql(packet: ByteArray, offset: Int, len: Int): Boolean {
+        // Server greeting: 3-byte len + seq 0 + protocol version 10 + version string
+        if (len < 10) return false
+        val payloadLen = (packet[offset].toInt() and 0xff) or
+            ((packet[offset + 1].toInt() and 0xff) shl 8) or
+            ((packet[offset + 2].toInt() and 0xff) shl 16)
+        val seq = packet[offset + 3].toInt() and 0xff
+        val proto = packet[offset + 4].toInt() and 0xff
+        return seq == 0 && proto == 10 && payloadLen in 20..1024
+    }
+
+    private fun looksLikeMqtt(packet: ByteArray, offset: Int, len: Int): Boolean {
+        // CONNECT: type=1 (0x10), remaining length, protocol name MQTT / MQIsdp
+        if (len < 10) return false
+        if ((packet[offset].toInt() and 0xff) != 0x10) return false
+        // Skip remaining length (1–4 bytes varint)
+        var p = offset + 1
+        var mul = 1
+        var rem = 0
+        repeat(4) {
+            if (p >= offset + len) return false
+            val b = packet[p].toInt() and 0xff
+            p++
+            rem += (b and 0x7f) * mul
+            mul *= 128
+            if (b and 0x80 == 0) {
+                if (p + 2 > offset + len) return false
+                val nameLen = u16(packet, p)
+                p += 2
+                if (p + nameLen > offset + len || nameLen !in 4..6) return false
+                val name = String(packet, p, nameLen, StandardCharsets.US_ASCII)
+                return name == "MQTT" || name == "MQIsdp"
+            }
+        }
+        return false
+    }
+
+    private fun looksLikeStun(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (len < 20) return false
+        // First two bits must be 0; magic cookie at bytes 4..7
+        if ((packet[offset].toInt() and 0xC0) != 0) return false
+        return (packet[offset + 4].toInt() and 0xff) == 0x21 &&
+            (packet[offset + 5].toInt() and 0xff) == 0x12 &&
+            (packet[offset + 6].toInt() and 0xff) == 0xA4 &&
+            (packet[offset + 7].toInt() and 0xff) == 0x42
+    }
+
+    private fun looksLikeWireGuard(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (len < 4) return false
+        val type = packet[offset].toInt() and 0xff
+        // Types 1..4 with reserved zeros; handshake initiation is 148 bytes.
+        if (type !in 1..4) return false
+        if ((packet[offset + 1].toInt() and 0xff) != 0 ||
+            (packet[offset + 2].toInt() and 0xff) != 0 ||
+            (packet[offset + 3].toInt() and 0xff) != 0
+        ) {
+            return false
+        }
+        return when (type) {
+            1 -> len == 148
+            2 -> len == 92
+            3 -> len == 64
+            4 -> len >= 32
+            else -> false
+        }
+    }
+
+    private fun looksLikeOpenVpn(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (len < 2) return false
+        val opcode = (packet[offset].toInt() and 0xff) shr 3
+        // P_CONTROL_HARD_RESET_CLIENT_V2 = 7, V3 = 10, etc.
+        return opcode in 1..10 && len >= 14
+    }
+
+    private fun looksLikeNtp(
+        packet: ByteArray,
+        offset: Int,
+        len: Int,
+        info: IpPacketInfo,
+    ): Boolean {
+        if (len < 48) return false
+        if (info.dstPort != 123 && info.srcPort != 123) return false
+        val liVnMode = packet[offset].toInt() and 0xff
+        val version = (liVnMode ushr 3) and 0x07
+        val mode = liVnMode and 0x07
+        return version in 1..4 && mode in 1..5
+    }
+
+    private fun looksLikeDhcp(
+        packet: ByteArray,
+        offset: Int,
+        len: Int,
+        info: IpPacketInfo,
+    ): Boolean {
+        if (len < 240) return false
+        if (info.dstPort != 67 && info.dstPort != 68 &&
+            info.srcPort != 67 && info.srcPort != 68
+        ) {
+            return false
+        }
+        val op = packet[offset].toInt() and 0xff
+        if (op != 1 && op != 2) return false
+        // Magic cookie
+        return (packet[offset + 236].toInt() and 0xff) == 0x63 &&
+            (packet[offset + 237].toInt() and 0xff) == 0x82 &&
+            (packet[offset + 238].toInt() and 0xff) == 0x53 &&
+            (packet[offset + 239].toInt() and 0xff) == 0x63
+    }
+
+    private fun looksLikeTftp(
+        packet: ByteArray,
+        offset: Int,
+        len: Int,
+        info: IpPacketInfo,
+    ): Boolean {
+        if (len < 4) return false
+        if (info.dstPort != 69 && info.srcPort != 69) return false
+        val opcode = u16(packet, offset)
+        return opcode in 1..5
     }
 
     private fun transportPayloadOffset(
@@ -265,4 +794,75 @@ object ApplicationLayerDetector {
         }
         return true
     }
+
+    private fun asciiPrefix(packet: ByteArray, offset: Int, len: Int, max: Int): String? {
+        val n = minOf(len, max)
+        if (n <= 0) return null
+        val sb = StringBuilder(n)
+        for (i in 0 until n) {
+            val c = packet[offset + i].toInt() and 0xff
+            if (c == 0 || c == '\r'.code || c == '\n'.code) break
+            if (c in 32..126) sb.append(c.toChar()) else break
+        }
+        return sb.toString().takeIf { it.isNotBlank() }
+    }
+
+    private fun asciiContains(packet: ByteArray, offset: Int, len: Int, needle: String): Boolean {
+        if (len < needle.length) return false
+        outer@ for (i in 0..len - needle.length) {
+            for (j in needle.indices) {
+                if ((packet[offset + i + j].toInt() and 0xff).toChar() != needle[j]) continue@outer
+            }
+            return true
+        }
+        return false
+    }
+
+    /** IMAP tagged command: `a001 LOGIN …` */
+    private fun asciiStartsWithTagCommand(
+        packet: ByteArray,
+        offset: Int,
+        len: Int,
+        command: String,
+    ): Boolean {
+        if (len < command.length + 2) return false
+        var i = 0
+        while (i < len && i < 16) {
+            val c = packet[offset + i].toInt() and 0xff
+            if (c == ' '.code) {
+                return startsWithAscii(packet, offset + i + 1, len - i - 1, "$command ") ||
+                    startsWithAscii(packet, offset + i + 1, len - i - 1, command)
+            }
+            if (c !in 'A'.code..'Z'.code && c !in 'a'.code..'z'.code &&
+                c !in '0'.code..'9'.code && c != '.'.code
+            ) {
+                return false
+            }
+            i++
+        }
+        return false
+    }
+
+    private fun u16(packet: ByteArray, offset: Int): Int =
+        ((packet[offset].toInt() and 0xff) shl 8) or (packet[offset + 1].toInt() and 0xff)
+
+    private val HTTP_METHODS = arrayOf(
+        "GET ", "POST ", "HEAD ", "PUT ", "DELETE ", "OPTIONS ", "CONNECT ", "PATCH ",
+        "HTTP/1.", "HTTP/2",
+    )
+    private val SMTP_PREFIXES = arrayOf(
+        "EHLO ", "HELO ", "MAIL FROM:", "RCPT TO:", "DATA\r\n", "QUIT\r\n", "STARTTLS",
+    )
+    private val SIP_PREFIXES = arrayOf(
+        "INVITE ", "REGISTER ", "OPTIONS ", "BYE ", "ACK ", "CANCEL ", "SUBSCRIBE ",
+        "NOTIFY ", "SIP/2.0",
+    )
+    private val RTSP_PREFIXES = arrayOf(
+        "OPTIONS ", "DESCRIBE ", "SETUP ", "PLAY ", "TEARDOWN ", "PAUSE ", "RTSP/1.0",
+    )
+    private val IRC_PREFIXES = arrayOf(
+        "NICK ", "USER ", "JOIN ", "PRIVMSG ", "NOTICE ", "PING ", "PONG ", "CAP ",
+    )
+    private val HTTP_PORTS = setOf(80, 8080, 8000, 8008, 8888, 5000)
+    private val HTTPS_PORTS = setOf(443, 8443)
 }

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/firewall/ApplicationLayerDetector.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/firewall/ApplicationLayerDetector.kt
@@ -1,0 +1,268 @@
+package ltechnologies.onionphone.onionvpn.core.vpn.firewall
+
+import ltechnologies.onionphone.onionvpn.core.vpn.dns.DnsPacketParser
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+/**
+ * Lightweight DPI for firewall UX: classify TCP/UDP flows as DNS / HTTP / HTTPS / TLS / …
+ *
+ * Hot path must stay cheap — call only on cold ASK/DENY/journal paths, never on every packet.
+ *
+ * Detection order:
+ * 1. Payload signatures (DNS wire, HTTP methods, TLS ClientHello / record, QUIC)
+ * 2. Well-known port heuristics when the first packet has no payload (TCP SYN)
+ */
+object ApplicationLayerDetector {
+
+    data class Result(
+        /** Short label for notifications (DNS, HTTP, HTTPS, TLS, DoT, QUIC, TCP, UDP). */
+        val label: String,
+        /** Optional detail: QNAME, Host, SNI, HTTP method+path. */
+        val detail: String? = null,
+        val kind: Kind = Kind.UNKNOWN,
+    )
+
+    enum class Kind {
+        DNS,
+        HTTP,
+        HTTPS,
+        TLS,
+        DOT,
+        QUIC,
+        UNKNOWN,
+    }
+
+    fun classify(packet: ByteArray, length: Int, info: IpPacketInfo): Result {
+        val payloadOff = transportPayloadOffset(packet, length, info)
+        val payloadLen = if (payloadOff != null) length - payloadOff else 0
+
+        if (payloadOff != null && payloadLen > 0) {
+            payloadClassify(packet, payloadOff, payloadLen, info)?.let { return it }
+        }
+        return portHeuristic(info)
+    }
+
+    private fun payloadClassify(
+        packet: ByteArray,
+        offset: Int,
+        len: Int,
+        info: IpPacketInfo,
+    ): Result? {
+        if (looksLikeDns(packet, offset, len, info)) {
+            val parsed = DnsPacketParser.parse(packet, offset, len)
+            val qname = parsed?.qname?.takeIf { it.isNotBlank() }
+            val detail = when {
+                qname != null && parsed?.isResponse == true -> "DNS response $qname"
+                qname != null -> "DNS query $qname"
+                else -> null
+            }
+            return Result(label = "DNS", detail = detail, kind = Kind.DNS)
+        }
+
+        if (info.isTcp && looksLikeHttp(packet, offset, len)) {
+            val preview = httpPreview(packet, offset, len)
+            return Result(label = "HTTP", detail = preview, kind = Kind.HTTP)
+        }
+
+        if (info.isTcp && looksLikeTls(packet, offset, len)) {
+            val sni = extractTlsSni(packet, offset, len)
+            val https = info.dstPort == 443 || info.dstPort == 8443
+            return Result(
+                label = if (https) "HTTPS" else "TLS",
+                detail = sni?.let { "SNI $it" },
+                kind = if (https) Kind.HTTPS else Kind.TLS,
+            )
+        }
+
+        if (info.isUdp && looksLikeQuic(packet, offset, len, info)) {
+            return Result(label = "QUIC", detail = "UDP/${info.dstPort}", kind = Kind.QUIC)
+        }
+
+        return null
+    }
+
+    private fun portHeuristic(info: IpPacketInfo): Result = when {
+        info.dstPort == 53 || info.srcPort == 53 ->
+            Result(label = "DNS", detail = null, kind = Kind.DNS)
+        info.dstPort == 853 ->
+            Result(label = "DoT", detail = "TLS DNS :853", kind = Kind.DOT)
+        info.isTcp && (info.dstPort == 80 || info.dstPort == 8080 || info.dstPort == 8000) ->
+            Result(label = "HTTP", detail = "port ${info.dstPort}", kind = Kind.HTTP)
+        info.isTcp && (info.dstPort == 443 || info.dstPort == 8443) ->
+            Result(label = "HTTPS", detail = "port ${info.dstPort}", kind = Kind.HTTPS)
+        info.isUdp && (info.dstPort == 443 || info.dstPort == 80) ->
+            Result(label = "QUIC", detail = "port ${info.dstPort}", kind = Kind.QUIC)
+        info.isTcp ->
+            Result(label = "TCP", detail = null, kind = Kind.UNKNOWN)
+        info.isUdp ->
+            Result(label = "UDP", detail = null, kind = Kind.UNKNOWN)
+        else ->
+            Result(
+                label = IpPacketParser.protocolLabel(info.protocol),
+                detail = null,
+                kind = Kind.UNKNOWN,
+            )
+    }
+
+    /**
+     * DNS wire format: 12-byte header, QDCOUNT ≥ 1 for queries, sane flag bits.
+     * Port 53 strongly preferred; also accept clear DNS shape on other ports (DoH-less plain DNS).
+     */
+    private fun looksLikeDns(packet: ByteArray, offset: Int, len: Int, info: IpPacketInfo): Boolean {
+        if (len < 12) return false
+        val onDnsPort = info.dstPort == 53 || info.srcPort == 53
+        val flags = ((packet[offset + 2].toInt() and 0xff) shl 8) or
+            (packet[offset + 3].toInt() and 0xff)
+        val opcode = (flags ushr 11) and 0x0f
+        if (opcode > 2) return false
+        val qd = ((packet[offset + 4].toInt() and 0xff) shl 8) or
+            (packet[offset + 5].toInt() and 0xff)
+        val an = ((packet[offset + 6].toInt() and 0xff) shl 8) or
+            (packet[offset + 7].toInt() and 0xff)
+        val ns = ((packet[offset + 8].toInt() and 0xff) shl 8) or
+            (packet[offset + 9].toInt() and 0xff)
+        val ar = ((packet[offset + 10].toInt() and 0xff) shl 8) or
+            (packet[offset + 11].toInt() and 0xff)
+        if (qd > 16 || an > 64 || ns > 64 || ar > 64) return false
+        if (qd == 0 && an == 0) return false
+        val parsed = DnsPacketParser.parse(packet, offset, len)
+        if (parsed?.qname != null) return true
+        return onDnsPort && qd >= 1
+    }
+
+    private fun looksLikeHttp(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (len < 4) return false
+        val methods = arrayOf(
+            "GET ", "POST ", "HEAD ", "PUT ", "DELETE ", "OPTIONS ", "CONNECT ", "PATCH ",
+            "HTTP/1.",
+        )
+        for (m in methods) {
+            if (startsWithAscii(packet, offset, len, m)) return true
+        }
+        return false
+    }
+
+    private fun httpPreview(packet: ByteArray, offset: Int, len: Int): String? {
+        val max = minOf(len, 256)
+        val text = String(packet, offset, max, StandardCharsets.US_ASCII)
+        val firstLine = text.lineSequence().firstOrNull()?.trim().orEmpty()
+        if (firstLine.isEmpty()) return null
+        val host = Regex("""(?im)^Host:\s*(\S+)""")
+            .find(text)?.groupValues?.getOrNull(1)
+        val line = firstLine.take(80)
+        return if (host != null) "$line · Host $host" else line
+    }
+
+    /** TLS record: content-type 0x14–0x17, version 0x03 0x01–0x04. */
+    private fun looksLikeTls(packet: ByteArray, offset: Int, len: Int): Boolean {
+        if (len < 5) return false
+        val type = packet[offset].toInt() and 0xff
+        if (type !in 0x14..0x17) return false
+        val major = packet[offset + 1].toInt() and 0xff
+        val minor = packet[offset + 2].toInt() and 0xff
+        return major == 0x03 && minor <= 0x04
+    }
+
+    /**
+     * Best-effort SNI from a TLS ClientHello (handshake type 0x01).
+     * Returns null if truncated / encrypted / not a ClientHello.
+     */
+    fun extractTlsSni(packet: ByteArray, offset: Int, len: Int): String? {
+        if (len < 9) return null
+        if ((packet[offset].toInt() and 0xff) != 0x16) return null // handshake record
+        val recordLen = ((packet[offset + 3].toInt() and 0xff) shl 8) or
+            (packet[offset + 4].toInt() and 0xff)
+        if (recordLen < 4 || 5 + recordLen > len) {
+            // Allow truncated first segment — parse what we have.
+        }
+        var p = offset + 5
+        val end = offset + minOf(len, 5 + maxOf(recordLen, 0))
+        if (p >= end) return null
+        if ((packet[p].toInt() and 0xff) != 0x01) return null // client_hello
+        p += 1
+        if (p + 3 > end) return null
+        val helloLen = ((packet[p].toInt() and 0xff) shl 16) or
+            ((packet[p + 1].toInt() and 0xff) shl 8) or
+            (packet[p + 2].toInt() and 0xff)
+        p += 3
+        val helloEnd = minOf(end, p + helloLen)
+        if (p + 2 + 32 + 1 > helloEnd) return null
+        p += 2 // client_version
+        p += 32 // random
+        if (p >= helloEnd) return null
+        val sessionLen = packet[p].toInt() and 0xff
+        p += 1 + sessionLen
+        if (p + 2 > helloEnd) return null
+        val cipherLen = ((packet[p].toInt() and 0xff) shl 8) or (packet[p + 1].toInt() and 0xff)
+        p += 2 + cipherLen
+        if (p + 1 > helloEnd) return null
+        val compLen = packet[p].toInt() and 0xff
+        p += 1 + compLen
+        if (p + 2 > helloEnd) return null
+        val extLen = ((packet[p].toInt() and 0xff) shl 8) or (packet[p + 1].toInt() and 0xff)
+        p += 2
+        val extEnd = minOf(helloEnd, p + extLen)
+        while (p + 4 <= extEnd) {
+            val type = ((packet[p].toInt() and 0xff) shl 8) or (packet[p + 1].toInt() and 0xff)
+            val elen = ((packet[p + 2].toInt() and 0xff) shl 8) or (packet[p + 3].toInt() and 0xff)
+            p += 4
+            if (p + elen > extEnd) break
+            if (type == 0x0000 && elen >= 5) { // server_name
+                // list_len(2) name_type(1) name_len(2) name
+                var q = p + 2
+                if (q + 3 > p + elen) break
+                val nameType = packet[q].toInt() and 0xff
+                q += 1
+                val nameLen = ((packet[q].toInt() and 0xff) shl 8) or (packet[q + 1].toInt() and 0xff)
+                q += 2
+                if (nameType == 0 && q + nameLen <= p + elen && nameLen in 1..253) {
+                    return String(packet, q, nameLen, StandardCharsets.US_ASCII)
+                        .lowercase(Locale.US)
+                }
+            }
+            p += elen
+        }
+        return null
+    }
+
+    /** QUIC long-header packets set the high bit of the first byte (RFC 9000). */
+    private fun looksLikeQuic(packet: ByteArray, offset: Int, len: Int, info: IpPacketInfo): Boolean {
+        if (len < 5) return false
+        if (info.dstPort != 443 && info.dstPort != 80) return false
+        val b0 = packet[offset].toInt() and 0xff
+        return (b0 and 0x80) != 0
+    }
+
+    private fun transportPayloadOffset(
+        packet: ByteArray,
+        length: Int,
+        info: IpPacketInfo,
+    ): Int? {
+        if (length < 20) return null
+        val ihl = (packet[0].toInt() and 0x0f) * 4
+        if (ihl < 20 || length < ihl) return null
+        return when {
+            info.isTcp -> {
+                if (length < ihl + 20) return null
+                val dataOff = ((packet[ihl + 12].toInt() and 0xff) ushr 4) * 4
+                if (dataOff < 20) return null
+                val off = ihl + dataOff
+                if (off > length) null else off
+            }
+            info.isUdp -> {
+                val off = ihl + 8
+                if (off > length) null else off
+            }
+            else -> null
+        }
+    }
+
+    private fun startsWithAscii(packet: ByteArray, offset: Int, len: Int, prefix: String): Boolean {
+        if (len < prefix.length) return false
+        for (i in prefix.indices) {
+            if ((packet[offset + i].toInt() and 0xff).toChar() != prefix[i]) return false
+        }
+        return true
+    }
+}

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/net/TorBandwidthSampler.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/net/TorBandwidthSampler.kt
@@ -7,12 +7,17 @@ import kotlin.math.abs
 import kotlin.math.max
 
 /**
- * Measures **Tor clearnet bandwidth** for OnionVPN's UID.
+ * Fallback sampler for **aggregate Tor clearnet bandwidth** (OnionVPN UID).
+ *
+ * Prefer ControlPort `traffic/read|written` deltas (all circuits) in the foreground
+ * service; this UID path is the last resort when control is unavailable.
  *
  * Tor (and DNSCrypt) run in our process UID and are [VpnService.Builder.addDisallowedApplication]
  * self-excluded, so their guard/middle/exit TCP shows up on [TrafficStats.getUidRxBytes] /
  * [TrafficStats.getUidTxBytes] — not on the TUN. App payload through hev is attributed to
  * other UIDs; [TProxyService.TProxyGetStats] is only a secondary "tunnel payload" hint.
+ *
+ * Counters cover **all** OR connections / circuits for this UID — never a single circuit.
  *
  * @see android.net.TrafficStats
  * @see android.net.VpnService

--- a/core/vpn/src/test/java/ltechnologies/onionphone/onionvpn/core/vpn/firewall/ApplicationLayerDetectorTest.kt
+++ b/core/vpn/src/test/java/ltechnologies/onionphone/onionvpn/core/vpn/firewall/ApplicationLayerDetectorTest.kt
@@ -1,0 +1,168 @@
+package ltechnologies.onionphone.onionvpn.core.vpn.firewall
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApplicationLayerDetectorTest {
+
+    @Test
+    fun tcpSyn443LabeledHttps() {
+        val packet = tcpSynPacket(dstPort = 443)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("HTTPS", dpi.label)
+        assertEquals(ApplicationLayerDetector.Kind.HTTPS, dpi.kind)
+    }
+
+    @Test
+    fun tcpSyn80LabeledHttp() {
+        val packet = tcpSynPacket(dstPort = 80)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("HTTP", dpi.label)
+    }
+
+    @Test
+    fun udpDnsQueryDetectedWithQname() {
+        // IPv4 + UDP/53 + minimal DNS query for example.com A
+        val dns = byteArrayOf(
+            0x12, 0x34.toByte(), // id
+            0x01, 0x00, // flags RD
+            0x00, 0x01, // qd=1
+            0x00, 0x00, // an
+            0x00, 0x00, // ns
+            0x00, 0x00, // ar
+            0x07, 'e'.code.toByte(), 'x'.code.toByte(), 'a'.code.toByte(),
+            'm'.code.toByte(), 'p'.code.toByte(), 'l'.code.toByte(), 'e'.code.toByte(),
+            0x03, 'c'.code.toByte(), 'o'.code.toByte(), 'm'.code.toByte(),
+            0x00,
+            0x00, 0x01, // A
+            0x00, 0x01, // IN
+        )
+        val packet = udpPacket(dstPort = 53, payload = dns)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("DNS", dpi.label)
+        assertEquals(ApplicationLayerDetector.Kind.DNS, dpi.kind)
+        assertNotNull(dpi.detail)
+        assertTrue(dpi.detail!!.contains("example.com"))
+    }
+
+    @Test
+    fun httpGetPayloadDetected() {
+        val http = "GET /index.html HTTP/1.1\r\nHost: example.org\r\n\r\n"
+            .toByteArray(Charsets.US_ASCII)
+        val packet = tcpDataPacket(dstPort = 80, payload = http, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("HTTP", dpi.label)
+        assertTrue(dpi.detail!!.contains("Host example.org") || dpi.detail!!.contains("GET"))
+    }
+
+    @Test
+    fun tlsClientHelloLabeledHttpsOn443() {
+        // Minimal TLS record header + ClientHello type (no full SNI required)
+        val payload = ByteArray(48)
+        payload[0] = 0x16 // handshake
+        payload[1] = 0x03
+        payload[2] = 0x01
+        payload[3] = 0x00
+        payload[4] = 43 // record length
+        payload[5] = 0x01 // client_hello
+        payload[6] = 0x00
+        payload[7] = 0x00
+        payload[8] = 39
+        val packet = tcpDataPacket(dstPort = 443, payload = payload, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("HTTPS", dpi.label)
+        assertEquals(ApplicationLayerDetector.Kind.HTTPS, dpi.kind)
+    }
+
+    @Test
+    fun udp443QuicLongHeader() {
+        val payload = byteArrayOf(0xC0.toByte(), 0x00, 0x00, 0x01, 0x01)
+        val packet = udpPacket(dstPort = 443, payload = payload)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("QUIC", dpi.label)
+    }
+
+    @Test
+    fun tcp853LabeledDot() {
+        val packet = tcpSynPacket(dstPort = 853)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("DoT", dpi.label)
+    }
+
+    private fun tcpSynPacket(dstPort: Int): ByteArray {
+        val packet = ByteArray(40)
+        packet[0] = 0x45.toByte()
+        packet[9] = 6
+        packet[12] = 10
+        packet[13] = 8
+        packet[14] = 0
+        packet[15] = 2
+        packet[16] = 1
+        packet[17] = 2
+        packet[18] = 3
+        packet[19] = 4
+        packet[20] = 0x30
+        packet[21] = 0x39
+        packet[22] = (dstPort ushr 8).toByte()
+        packet[23] = dstPort.toByte()
+        packet[32] = 0x50 // data offset 5 (20 bytes)
+        packet[33] = 0x02 // SYN
+        return packet
+    }
+
+    private fun tcpDataPacket(dstPort: Int, payload: ByteArray, syn: Boolean): ByteArray {
+        val header = 40
+        val packet = ByteArray(header + payload.size)
+        packet[0] = 0x45.toByte()
+        packet[9] = 6
+        packet[12] = 10
+        packet[13] = 8
+        packet[14] = 0
+        packet[15] = 2
+        packet[16] = 1
+        packet[17] = 2
+        packet[18] = 3
+        packet[19] = 4
+        packet[20] = 0x30
+        packet[21] = 0x39
+        packet[22] = (dstPort ushr 8).toByte()
+        packet[23] = dstPort.toByte()
+        packet[32] = 0x50
+        packet[33] = if (syn) 0x02 else 0x18 // PSH+ACK
+        System.arraycopy(payload, 0, packet, header, payload.size)
+        return packet
+    }
+
+    private fun udpPacket(dstPort: Int, payload: ByteArray): ByteArray {
+        val header = 28
+        val packet = ByteArray(header + payload.size)
+        packet[0] = 0x45.toByte()
+        packet[9] = 17
+        packet[12] = 10
+        packet[13] = 8
+        packet[14] = 0
+        packet[15] = 2
+        packet[16] = 8
+        packet[17] = 8
+        packet[18] = 8
+        packet[19] = 8
+        packet[20] = 0xC0.toByte()
+        packet[21] = 0x00
+        packet[22] = (dstPort ushr 8).toByte()
+        packet[23] = dstPort.toByte()
+        val udpLen = 8 + payload.size
+        packet[24] = (udpLen ushr 8).toByte()
+        packet[25] = udpLen.toByte()
+        System.arraycopy(payload, 0, packet, header, payload.size)
+        return packet
+    }
+}

--- a/core/vpn/src/test/java/ltechnologies/onionphone/onionvpn/core/vpn/firewall/ApplicationLayerDetectorTest.kt
+++ b/core/vpn/src/test/java/ltechnologies/onionphone/onionvpn/core/vpn/firewall/ApplicationLayerDetectorTest.kt
@@ -25,21 +25,42 @@ class ApplicationLayerDetectorTest {
     }
 
     @Test
+    fun tcpSyn22LabeledSsh() {
+        val packet = tcpSynPacket(dstPort = 22)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("SSH", dpi.label)
+    }
+
+    @Test
+    fun tcpSyn25LabeledSmtp() {
+        val packet = tcpSynPacket(dstPort = 25)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("SMTP", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun tcpSyn3389LabeledRdp() {
+        val packet = tcpSynPacket(dstPort = 3389)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("RDP", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
     fun udpDnsQueryDetectedWithQname() {
-        // IPv4 + UDP/53 + minimal DNS query for example.com A
         val dns = byteArrayOf(
-            0x12, 0x34.toByte(), // id
-            0x01, 0x00, // flags RD
-            0x00, 0x01, // qd=1
-            0x00, 0x00, // an
-            0x00, 0x00, // ns
-            0x00, 0x00, // ar
+            0x12, 0x34.toByte(),
+            0x01, 0x00,
+            0x00, 0x01,
+            0x00, 0x00,
+            0x00, 0x00,
+            0x00, 0x00,
             0x07, 'e'.code.toByte(), 'x'.code.toByte(), 'a'.code.toByte(),
             'm'.code.toByte(), 'p'.code.toByte(), 'l'.code.toByte(), 'e'.code.toByte(),
             0x03, 'c'.code.toByte(), 'o'.code.toByte(), 'm'.code.toByte(),
             0x00,
-            0x00, 0x01, // A
-            0x00, 0x01, // IN
+            0x00, 0x01,
+            0x00, 0x01,
         )
         val packet = udpPacket(dstPort = 53, payload = dns)
         val info = IpPacketParser.parse(packet, packet.size)!!
@@ -48,6 +69,13 @@ class ApplicationLayerDetectorTest {
         assertEquals(ApplicationLayerDetector.Kind.DNS, dpi.kind)
         assertNotNull(dpi.detail)
         assertTrue(dpi.detail!!.contains("example.com"))
+    }
+
+    @Test
+    fun mdnsPortLabeled() {
+        val packet = udpPacket(dstPort = 5353, payload = ByteArray(12))
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("mDNS", ApplicationLayerDetector.classify(packet, packet.size, info).label)
     }
 
     @Test
@@ -62,15 +90,52 @@ class ApplicationLayerDetectorTest {
     }
 
     @Test
+    fun dohHttpDetected() {
+        val http = "POST /dns-query HTTP/1.1\r\nHost: dns.google\r\nContent-Type: application/dns-message\r\n\r\n"
+            .toByteArray(Charsets.US_ASCII)
+        val packet = tcpDataPacket(dstPort = 443, payload = http, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("DoH", dpi.label)
+        assertEquals(ApplicationLayerDetector.Kind.DOH, dpi.kind)
+    }
+
+    @Test
+    fun websocketUpgradeDetected() {
+        val http = "GET /chat HTTP/1.1\r\nHost: example.com\r\nUpgrade: websocket\r\nSec-WebSocket-Key: x\r\n\r\n"
+            .toByteArray(Charsets.US_ASCII)
+        val packet = tcpDataPacket(dstPort = 80, payload = http, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("WebSocket", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun http2PrefaceDetected() {
+        val preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".toByteArray(Charsets.US_ASCII)
+        val packet = tcpDataPacket(dstPort = 80, payload = preface, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("HTTP/2", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun sshBannerDetected() {
+        val banner = "SSH-2.0-OpenSSH_9.0\r\n".toByteArray(Charsets.US_ASCII)
+        val packet = tcpDataPacket(dstPort = 22, payload = banner, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
+        assertEquals("SSH", dpi.label)
+        assertTrue(dpi.detail!!.contains("OpenSSH"))
+    }
+
+    @Test
     fun tlsClientHelloLabeledHttpsOn443() {
-        // Minimal TLS record header + ClientHello type (no full SNI required)
         val payload = ByteArray(48)
-        payload[0] = 0x16 // handshake
+        payload[0] = 0x16
         payload[1] = 0x03
         payload[2] = 0x01
         payload[3] = 0x00
-        payload[4] = 43 // record length
-        payload[5] = 0x01 // client_hello
+        payload[4] = 43
+        payload[5] = 0x01
         payload[6] = 0x00
         payload[7] = 0x00
         payload[8] = 39
@@ -82,12 +147,112 @@ class ApplicationLayerDetectorTest {
     }
 
     @Test
-    fun udp443QuicLongHeader() {
+    fun tlsOn993LabeledImaps() {
+        val payload = ByteArray(48)
+        payload[0] = 0x16
+        payload[1] = 0x03
+        payload[2] = 0x01
+        payload[3] = 0x00
+        payload[4] = 43
+        payload[5] = 0x01
+        val packet = tcpDataPacket(dstPort = 993, payload = payload, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("IMAPS", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun udp443QuicLabeledHttp3() {
         val payload = byteArrayOf(0xC0.toByte(), 0x00, 0x00, 0x01, 0x01)
         val packet = udpPacket(dstPort = 443, payload = payload)
         val info = IpPacketParser.parse(packet, packet.size)!!
         val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
-        assertEquals("QUIC", dpi.label)
+        assertEquals("HTTP/3", dpi.label)
+        assertEquals(ApplicationLayerDetector.Kind.QUIC, dpi.kind)
+    }
+
+    @Test
+    fun stunMagicCookieDetected() {
+        val payload = ByteArray(20)
+        payload[0] = 0x00
+        payload[1] = 0x01 // binding request
+        payload[4] = 0x21
+        payload[5] = 0x12
+        payload[6] = 0xA4.toByte()
+        payload[7] = 0x42
+        val packet = udpPacket(dstPort = 3478, payload = payload)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("STUN", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun wireGuardHandshakeDetected() {
+        val payload = ByteArray(148)
+        payload[0] = 1 // initiation
+        val packet = udpPacket(dstPort = 51820, payload = payload)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("WireGuard", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun mqttConnectDetected() {
+        // Fixed header 0x10, remaining len, name len=4 "MQTT", level, flags, keepalive
+        val payload = byteArrayOf(
+            0x10, 0x0C,
+            0x00, 0x04,
+            'M'.code.toByte(), 'Q'.code.toByte(), 'T'.code.toByte(), 'T'.code.toByte(),
+            0x04, 0x02, 0x00, 0x3C,
+            0x00, 0x00,
+        )
+        val packet = tcpDataPacket(dstPort = 1883, payload = payload, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("MQTT", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun sipInviteDetected() {
+        val sip = "INVITE sip:bob@example.com SIP/2.0\r\n".toByteArray(Charsets.US_ASCII)
+        val packet = udpPacket(dstPort = 5060, payload = sip)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("SIP", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun socks5GreetingDetected() {
+        val payload = byteArrayOf(0x05, 0x01, 0x00)
+        val packet = tcpDataPacket(dstPort = 1080, payload = payload, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("SOCKS5", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun rdpTpktDetected() {
+        val payload = byteArrayOf(
+            0x03, 0x00, 0x00, 0x2B,
+            0x26, 0xE0.toByte(), 0x00, 0x00,
+            0x00, 0x00, 0x00,
+        )
+        val packet = tcpDataPacket(dstPort = 3389, payload = payload, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("RDP", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun vncBannerDetected() {
+        val payload = "RFB 003.008\n".toByteArray(Charsets.US_ASCII)
+        val packet = tcpDataPacket(dstPort = 5900, payload = payload, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("VNC", ApplicationLayerDetector.classify(packet, packet.size, info).label)
+    }
+
+    @Test
+    fun bitTorrentHandshakeDetected() {
+        val payload = ByteArray(68)
+        payload[0] = 19
+        val proto = "BitTorrent protocol".toByteArray(Charsets.US_ASCII)
+        System.arraycopy(proto, 0, payload, 1, proto.size)
+        val packet = tcpDataPacket(dstPort = 6881, payload = payload, syn = false)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("BitTorrent", ApplicationLayerDetector.classify(packet, packet.size, info).label)
     }
 
     @Test
@@ -96,6 +261,17 @@ class ApplicationLayerDetectorTest {
         val info = IpPacketParser.parse(packet, packet.size)!!
         val dpi = ApplicationLayerDetector.classify(packet, packet.size, info)
         assertEquals("DoT", dpi.label)
+    }
+
+    @Test
+    fun dtlsRecordDetected() {
+        val payload = ByteArray(13)
+        payload[0] = 0x16
+        payload[1] = 0xFE.toByte()
+        payload[2] = 0xFD.toByte()
+        val packet = udpPacket(dstPort = 4433, payload = payload)
+        val info = IpPacketParser.parse(packet, packet.size)!!
+        assertEquals("DTLS", ApplicationLayerDetector.classify(packet, packet.size, info).label)
     }
 
     private fun tcpSynPacket(dstPort: Int): ByteArray {
@@ -114,8 +290,8 @@ class ApplicationLayerDetectorTest {
         packet[21] = 0x39
         packet[22] = (dstPort ushr 8).toByte()
         packet[23] = dstPort.toByte()
-        packet[32] = 0x50 // data offset 5 (20 bytes)
-        packet[33] = 0x02 // SYN
+        packet[32] = 0x50
+        packet[33] = 0x02
         return packet
     }
 
@@ -137,7 +313,7 @@ class ApplicationLayerDetectorTest {
         packet[22] = (dstPort ushr 8).toByte()
         packet[23] = dstPort.toByte()
         packet[32] = 0x50
-        packet[33] = if (syn) 0x02 else 0x18 // PSH+ACK
+        packet[33] = if (syn) 0x02 else 0x18
         System.arraycopy(payload, 0, packet, header, payload.size)
         return packet
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problème

1. L’indicateur de bande passante semblait refléter un seul circuit Tor plutôt que le débit global.
2. Les notifications d’autorisation de connexion n’affichaient que `TCP`/`UDP`, sans indiquer le protocole applicatif.

## Correctifs

### Bande passante agrégée (tous les circuits)
- Poll dédié `GETINFO traffic/read` + `traffic/written` à chaque tick (compteurs **process-wide**).
- Priorité : deltas traffic → événement control `BW` (aussi global) → fallback UID `TrafficStats`.
- **Jamais** `CIRC_BW` / `STREAM_BW` (par circuit / stream).
- Libellé clarifié : `Tor ▼ … ▲ … · N circuits`.

### DPI étendu sur les prompts firewall
`ApplicationLayerDetector` classifie via signatures payload + heuristiques de ports :

| Famille | Labels |
|--------|--------|
| Web | HTTP, HTTP/2, HTTP/3, HTTPS, WebSocket, DoH |
| DNS | DNS, mDNS, LLMNR, DoT |
| Crypto / VPN | TLS, DTLS, QUIC, SSH, WireGuard, OpenVPN, SOCKS |
| Mail | SMTP, SMTPS, IMAP, IMAPS, POP3, POP3S |
| VoIP / media | SIP, RTSP, STUN, SSDP |
| Infra | MQTT, RDP, VNC, FTP, NTP, DHCP, TFTP, XMPP, IRC, Git |
| Data | Redis, MySQL, PostgreSQL, MongoDB, BitTorrent |

Détails UX dans la notification : QNAME, Host, SNI, bannières (SSH…), etc. Sur un SYN TCP sans payload → heuristique de port.

## Tests
- `ApplicationLayerDetectorTest` (DNS, DoH, WebSocket, HTTP/2, HTTP/3, SSH, STUN, WireGuard, MQTT, SIP, SOCKS, RDP, VNC, BitTorrent, DTLS, IMAPS, …)
- `:app:compileDebugKotlin` OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22acf5cb-10d5-4a73-91ff-7f7e468823d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22acf5cb-10d5-4a73-91ff-7f7e468823d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

