### PR TITLE
fix(onionmasq): prevent isRunning SIGABRT before init (0.3.47)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "ltechnologies.onionphone.onionvpn"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 53
-        versionName = "0.3.46"
+        versionCode = 54
+        versionName = "0.3.47"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/OnionmasqTunForwarder.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/forwarder/OnionmasqTunForwarder.kt
@@ -22,6 +22,7 @@ import ltechnologies.onionphone.onionvpn.core.model.observability.OpTrace
 import ltechnologies.onionphone.onionvpn.core.model.stability.ProcessLogLevel
 import ltechnologies.onionphone.onionvpn.core.vpn.OnionVpnService
 import ltechnologies.onionphone.onionvpn.core.vpn.profile.TunForwarder
+import ltechnologies.onionphone.onionvpn.core.vpn.onionmasq.OnionmasqNativeGate
 import ltechnologies.onionphone.onionvpn.core.vpn.onionmasq.TorNativeAppUids
 import org.torproject.onionmasq.OnionMasq
 import org.torproject.onionmasq.events.BootstrapEvent
@@ -53,8 +54,13 @@ class OnionmasqTunForwarder(
     private val running = AtomicBoolean(false)
     /**
      * True once we have handed a TUN fd to [OnionMasq.start] (or are about to).
-     * Native [OnionMasq.stop]/[OnionMasqJni.closeProxy] **aborts** (Rust unwrap) if the
-     * control channel was never opened — [runCatching] cannot catch SIGABRT.
+     *
+     * Native [OnionMasq.stop] / [OnionMasq.isRunning] call `OnionmasqMobile::get()`, which
+     * **expect()-aborts** (SIGABRT; panic=abort) when `init()` has not run. [runCatching]
+     * cannot catch that. Gate every native stop/probe on this flag — never on JNI isRunning.
+     *
+     * Regression: 0.3.46 stop() probed [OnionMasq.isRunning] before init → tombstone
+     * `Java_org_torproject_onionmasq_OnionMasqJni_isRunning` → `unwrap_failed`.
      */
     private val proxyOwned = AtomicBoolean(false)
     private var dnsMux: TunDnsMux? = null
@@ -71,9 +77,8 @@ class OnionmasqTunForwarder(
         synthesizeOnionAutomap: Boolean,
     ) {
         OpTrace.step("onionmasq", "start dnsCrypt=$dnsCryptPort", ProcessLogLevel.INFO) {
-            // Tear down a prior start on *this* instance only. Never call closeProxy when
-            // onionmasq was not started — that path SIGABRTs inside libonionmasq_mobile.so
-            // (seen on 0.3.45: startForwarder → stop → closeProxy unwrap_failed).
+            // Tear down a prior start on *this* instance only. stop() must not touch JNI
+            // unless proxyOwned — start() runs before init on a fresh instance.
             stop()
             if (dnsMode != DnsResolverMode.DNSCRYPT_MUX) {
                 Timber.i("dnsMode=$dnsMode coerced to DNSCRYPT_MUX divert for onionmasq")
@@ -155,6 +160,8 @@ class OnionmasqTunForwarder(
                     )
                 } finally {
                     running.set(false)
+                    // start() has returned (drop_command_sender already ran). Clear ownership
+                    // so a later stop() on this instance does not re-enter closeProxy needlessly.
                     proxyOwned.set(false)
                 }
             }
@@ -165,16 +172,15 @@ class OnionmasqTunForwarder(
     override fun stop() {
         OpTrace.debug("onionmasq", "stop")
         running.set(false)
-        proxyOwned.set(false)
         detachEventObserver()
-        // closeProxy aborts (Rust unwrap → SIGABRT) when the control channel was never
-        // opened. isRunning() is the only safe gate — runCatching cannot catch abort.
-        val nativeUp = runCatching { OnionMasq.isRunning() }.getOrDefault(false)
-        if (nativeUp) {
+        // Ownership gate only — do NOT call OnionMasq.isRunning() here.
+        // Pre-init isRunning/closeProxy → OnionmasqMobile::get expect → SIGABRT.
+        val owned = proxyOwned.getAndSet(false)
+        if (OnionmasqNativeGate.mayStopNativeProxy(owned)) {
             runCatching { OnionMasq.stop() }
                 .onFailure { Timber.w(it, "OnionMasq.stop failed") }
         } else {
-            Timber.d("OnionMasq.stop skipped — proxy not running")
+            Timber.d("OnionMasq.stop skipped — proxy not owned (pre-init or never started)")
         }
         dnsMux?.stop()
         dnsMux = null
@@ -185,7 +191,7 @@ class OnionmasqTunForwarder(
         omEnd = null
     }
 
-    fun isRunning(): Boolean = running.get() && OnionMasq.isRunning()
+    fun isRunning(): Boolean = running.get() && proxyOwned.get()
 
     private fun attachEventObserver() {
         val observer = Observer<OnionmasqEvent> { event ->

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/onionmasq/OnionmasqNativeGate.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/onionmasq/OnionmasqNativeGate.kt
@@ -1,0 +1,27 @@
+package ltechnologies.onionphone.onionvpn.core.vpn.onionmasq
+
+/**
+ * Decision helpers for onionmasq JNI calls that abort the process when mis-ordered.
+ *
+ * Upstream `libonionmasq_mobile.so` uses `panic = "abort"`. Several JNI entry points
+ * call `OnionmasqMobile::get()`, which `expect()`s that `OnionMasqJni.init()` has
+ * already succeeded. [kotlin.Result]/`runCatching` cannot catch SIGABRT.
+ *
+ * Tombstone (0.3.46 / versionCode 53): `startForwarder` → `stop` →
+ * `OnionMasqJni.isRunning` → `unwrap_failed` → SIGABRT, because `start()` called
+ * `stop()` before `OnionMasq.init()`.
+ */
+object OnionmasqNativeGate {
+    /**
+     * Native [org.torproject.onionmasq.OnionMasq.stop] / `closeProxy` may only run
+     * after we have handed a TUN fd to [org.torproject.onionmasq.OnionMasq.start]
+     * on this forwarder instance (`proxyOwned`).
+     */
+    fun mayStopNativeProxy(proxyOwned: Boolean): Boolean = proxyOwned
+
+    /**
+     * Native [org.torproject.onionmasq.OnionMasq.isRunning] requires Java/native init.
+     * Prefer Kotlin ownership flags over probing JNI before init.
+     */
+    fun mayProbeNativeRunning(javaInitialized: Boolean): Boolean = javaInitialized
+}

--- a/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/onionmasq/OnionmasqSocksSidecar.kt
+++ b/core/vpn/src/main/java/ltechnologies/onionphone/onionvpn/core/vpn/onionmasq/OnionmasqSocksSidecar.kt
@@ -22,7 +22,9 @@ object OnionmasqSocksSidecar {
 
     /** Bound sidecar port, or 0 if onionmasq is not running / sidecar down. */
     fun socksPortOrZero(): Int {
-        if (!OnionMasq.isRunning()) return 0
+        // OnionMasq.isRunning()/getSocksSidecarPort are Java-hardened for pre-init,
+        // but still avoid probing when the helper reports uninitialized.
+        if (!OnionMasq.isInitialized() || !OnionMasq.isRunning()) return 0
         return runCatching { OnionMasq.getSocksSidecarPort().toInt() }
             .onFailure { Timber.w(it, "getSocksSidecarPort") }
             .getOrDefault(0)

--- a/core/vpn/src/test/java/ltechnologies/onionphone/onionvpn/core/vpn/onionmasq/OnionmasqNativeGateTest.kt
+++ b/core/vpn/src/test/java/ltechnologies/onionphone/onionvpn/core/vpn/onionmasq/OnionmasqNativeGateTest.kt
@@ -1,0 +1,28 @@
+package ltechnologies.onionphone.onionvpn.core.vpn.onionmasq
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression: 0.3.46 called native isRunning()/closeProxy from stop() before init,
+ * which SIGABRTs inside libonionmasq_mobile.so (unwrap on OnionmasqMobile::get).
+ */
+class OnionmasqNativeGateTest {
+    @Test
+    fun stopSkippedWhenProxyNeverOwned() {
+        // start() invokes stop() on a fresh forwarder — must not touch JNI.
+        assertFalse(OnionmasqNativeGate.mayStopNativeProxy(proxyOwned = false))
+    }
+
+    @Test
+    fun stopAllowedOnlyAfterFdHandedToNative() {
+        assertTrue(OnionmasqNativeGate.mayStopNativeProxy(proxyOwned = true))
+    }
+
+    @Test
+    fun nativeRunningProbeRequiresJavaInit() {
+        assertFalse(OnionmasqNativeGate.mayProbeNativeRunning(javaInitialized = false))
+        assertTrue(OnionmasqNativeGate.mayProbeNativeRunning(javaInitialized = true))
+    }
+}

--- a/docs/TUN_DATA_PLANE.md
+++ b/docs/TUN_DATA_PLANE.md
@@ -39,6 +39,14 @@ DNSCrypt upstream → SOCKS IsolationToken
 
 OnionVPN keeps fail-closed routing (no Tor VPN `allowFamily`). Own package stays disallowed from the VPN; onionmasq/Arti sockets use clearnet uplink via `protect`. Tor-native apps (Orbot, Tor Browser, …) are `setExcludedUids` so they are not double-proxied.
 
+### Lifecycle (native abort hazard)
+
+`libonionmasq_mobile.so` uses `panic=abort`. JNI helpers that call `OnionmasqMobile::get()`
+**kill the process** if `OnionMasq.init()` has not succeeded — including `isRunning()` and
+`closeProxy()`. `OnionmasqTunForwarder.start()` calls `stop()` before `init()`; stop must
+gate on Kotlin `proxyOwned` only (never probe native `isRunning` pre-init). See
+`OnionmasqNativeGate` and `native/onionmasq/safe-uninit-jni.patch`.
+
 ### Capability matrix
 
 | Engine / plane | Circuits UI | NEWNYM | DNSCrypt SOCKS |

--- a/native/onionmasq/README.md
+++ b/native/onionmasq/README.md
@@ -28,9 +28,15 @@ App DNS still goes TunDnsMux → DNSCrypt. Upstream SOCKS:
 2. **Interim cold-start:** arti-mobile SOCKS + DNSPort until the orchestrator
    starts DNSCrypt after onionmasq is ready (`OnionmasqSocksSidecar.INTERIM_USES_ARTI_MOBILE`).
 
-Re-apply the sidecar after a clean onionmasq clone:
+Re-apply OnionVPN patches after a clean onionmasq clone:
 
 ```bash
 cd third_party/onionmasq
 git apply ../../native/onionmasq/socks-sidecar.patch
+git apply ../../native/onionmasq/safe-uninit-jni.patch
 ```
+
+`safe-uninit-jni.patch` makes `isRunning` / `closeProxy` / `getSocksSidecarPort`
+return safely when `init()` has not run (upstream `get().expect` + `panic=abort`
+otherwise SIGABRTs the app). The Java/Kotlin layers also gate these calls; rebuild
+the `.so` so the native side matches.

--- a/native/onionmasq/build-onionvpn.sh
+++ b/native/onionmasq/build-onionvpn.sh
@@ -18,6 +18,19 @@ export ANDROID_NDK="$ANDROID_NDK_HOME"
 ARCHS="${1:-arm64-v8a}"
 cd "$OM_SRC"
 
+# OnionVPN patches (idempotent via git apply --check when already applied).
+PATCH_DIR="$ROOT/native/onionmasq"
+for patch in socks-sidecar.patch safe-uninit-jni.patch; do
+  if [[ -f "$PATCH_DIR/$patch" ]]; then
+    if git apply --check "$PATCH_DIR/$patch" 2>/dev/null; then
+      git apply "$PATCH_DIR/$patch"
+      echo "Applied $patch"
+    else
+      echo "Skip $patch (already applied or not applicable)"
+    fi
+  fi
+done
+
 if [[ "${SKIP_NDK_VERSION_CHECK:-}" == "1" ]]; then
   # Temporarily relax build-ndk.sh version gate for local NDK variants.
   sed -i.bak 's/EXPECTED_NDK_VERSION=.*/EXPECTED_NDK_VERSION="$(basename "$ANDROID_NDK_ROOT")"/' build-ndk.sh

--- a/native/onionmasq/safe-uninit-jni.patch
+++ b/native/onionmasq/safe-uninit-jni.patch
@@ -1,0 +1,63 @@
+diff --git a/crates/onionmasq-mobile/src/ffi.rs b/crates/onionmasq-mobile/src/ffi.rs
+index a0f18ab..b1c2d0e 100644
+--- a/crates/onionmasq-mobile/src/ffi.rs
++++ b/crates/onionmasq-mobile/src/ffi.rs
+@@ -48,8 +48,11 @@ pub extern "C" fn Java_org_torproject_onionmasq_OnionMasqJni_closeProxy(
+     mut env: JNIEnv,
+     _: JClass,
+ ) {
+     panic_handling::capture_unwind!(env, {
+-        let mobile = OnionmasqMobile::get();
++        // Never expect()-abort when stop races ahead of init (Android VPN restart).
++        let Some(mobile) = OnionmasqMobile::try_get() else {
++            return;
++        };
+         if let Err(e) = mobile.stop_proxy() {
+             error!("closeProxy() returned error: {e:?}");
+             errors::throw_java_exception_for(&mut env, e).unwrap();
+@@ -62,14 +65,20 @@ pub extern "C" fn Java_org_torproject_onionmasq_OnionMasqJni_isRunning(
+     _: JClass,
+ ) -> jboolean {
+     panic_handling::capture_unwind!(env, {
+-        let mobile = OnionmasqMobile::get();
+-        anyhow::Ok(mobile.is_running()).expect("Could not determine running state")
++        // Return false when uninitialised — callers (e.g. ConnectivityHandler, VPN
++        // stop-before-start) probe isRunning before init. get().expect aborts the app.
++        match OnionmasqMobile::try_get() {
++            Some(mobile) => mobile.is_running(),
++            None => 0,
++        }
+     })
+ }
+ 
+ #[no_mangle]
+ pub extern "C" fn Java_org_torproject_onionmasq_OnionMasqJni_getSocksSidecarPort(
+     mut env: JNIEnv,
+     _: JClass,
+ ) -> jlong {
+     panic_handling::capture_unwind!(env, {
+-        anyhow::Ok(OnionmasqMobile::get().socks_sidecar_port())
+-            .expect("Could not read SOCKS sidecar port")
++        match OnionmasqMobile::try_get() {
++            Some(mobile) => mobile.socks_sidecar_port(),
++            None => 0,
++        }
+     })
+ }
+diff --git a/crates/onionmasq-mobile/src/lib.rs b/crates/onionmasq-mobile/src/lib.rs
+index 4a4cf12..c9e8f01 100644
+--- a/crates/onionmasq-mobile/src/lib.rs
++++ b/crates/onionmasq-mobile/src/lib.rs
+@@ -169,6 +169,12 @@ impl OnionmasqMobile {
+             .expect("OnionmasqMobile::get() called without being initialised (did you forget to call init?)")
+     }
+ 
++    /// Like [`Self::get`], but returns `None` when `init()` has not run yet.
++    /// Prefer this for probe/stop JNI entry points that must not abort the process.
++    pub fn try_get() -> Option<&'static Self> {
++        ONIONMASQ_MOBILE_SINGLETON.get()
++    }
++
+     /// Get the Android API version.
+     pub fn get_android_api(&self) -> Result<i32> {
+         self.call_jni_class_method("getAndroidAPI", "()I", &[])

--- a/third_party/onionmasq-android/src/main/java/org/torproject/onionmasq/ConnectivityHandler.java
+++ b/third_party/onionmasq-android/src/main/java/org/torproject/onionmasq/ConnectivityHandler.java
@@ -50,7 +50,8 @@ public class ConnectivityHandler {
             super.onLost(network);
             LogObservable.getInstance().addLog("Internet connectivity lost.");
             try {
-                if (OnionMasq.isRunning()) {
+                // isRunning() is false (and JNI-safe) when init has not run.
+                if (OnionMasq.isInitialized() && OnionMasq.isRunning()) {
                     OnionMasqJni.setInternetConnectivity(false);
                 }
             } catch (ProxyStoppedException e) {
@@ -64,7 +65,7 @@ public class ConnectivityHandler {
             super.onCapabilitiesChanged(network, networkCapabilities);
             boolean hasInternetConnectivity = networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
             try {
-                if (OnionMasq.isRunning()) {
+                if (OnionMasq.isInitialized() && OnionMasq.isRunning()) {
                     OnionMasqJni.setInternetConnectivity(hasInternetConnectivity);
                 }
             } catch (ProxyStoppedException e) {

--- a/third_party/onionmasq-android/src/main/java/org/torproject/onionmasq/OnionMasq.java
+++ b/third_party/onionmasq-android/src/main/java/org/torproject/onionmasq/OnionMasq.java
@@ -246,17 +246,43 @@ public class OnionMasq {
         }
     }
 
+    /** True after a successful [init] (Java instance + native singleton). */
+    public static boolean isInitialized() {
+        return instance != null;
+    }
+
+    /**
+     * Whether the onionmasq control channel exists.
+     * <p>
+     * Safe before [init]: returns {@code false}. Calling into
+     * {@link OnionMasqJni#isRunning()} before native init aborts the process
+     * ({@code OnionmasqMobile::get().expect(...)} with {@code panic=abort}).
+     */
     public static boolean isRunning() {
+        if (instance == null) {
+            return false;
+        }
         return OnionMasqJni.isRunning();
     }
 
-    /** Loopback SOCKS5 port for DNSCrypt/probe (0 if sidecar not listening). */
+    /** Loopback SOCKS5 port for DNSCrypt/probe (0 if sidecar not listening / not init). */
     public static long getSocksSidecarPort() {
+        if (instance == null) {
+            return 0L;
+        }
         return OnionMasqJni.getSocksSidecarPort();
     }
 
+    /**
+     * Stops the proxy. No-op when [init] has not run — native {@code closeProxy}
+     * otherwise expect()-aborts.
+     */
     @WorkerThread
     public static void stop() {
+        if (instance == null) {
+            Log.d(TAG, "stop() skipped — OnionMasq not initialized");
+            return;
+        }
         OnionMasqJni.closeProxy();
         OnionMasqJni.resetCounters();
         getInstance().circuitStore.reset();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Android tombstone crash in `libonionmasq_mobile.so` where VPN start aborted with:

`Java_org_torproject_onionmasq_OnionMasqJni_isRunning` → `unwrap_failed` → SIGABRT

### Root cause

Upstream onionmasq JNI (`isRunning` / `closeProxy`) calls `OnionmasqMobile::get()`, which `expect()`s that native `init()` has already succeeded. With `panic=abort`, that kills the process — Kotlin `runCatching` cannot catch it.

`OnionmasqTunForwarder.start()` always calls `stop()` first. On 0.3.46, `stop()` probed `OnionMasq.isRunning()` before `OnionMasq.init()`, reproducing the abort on every fresh onionmasq establish (versionCode 53 / package `ltechnologies.onionphone.onionvpn`).

### Fix (defense in depth)

1. **Kotlin forwarder** — gate native `OnionMasq.stop()` on `proxyOwned` only (set when a TUN fd is handed to `OnionMasq.start`). Never probe JNI `isRunning` from `stop()`.
2. **Java API** — `OnionMasq.isRunning()` / `stop()` / `getSocksSidecarPort()` no-op safely when `init()` has not run; add `isInitialized()`.
3. **Connectivity / SOCKS sidecar** — check initialized before native probes.
4. **Native patch** — `native/onionmasq/safe-uninit-jni.patch` makes future `.so` rebuilds return false/no-op instead of `get().expect` for probe/stop entry points.
5. **Regression unit test** — `OnionmasqNativeGateTest`.
6. Version **0.3.47** (versionCode 54).

## Test plan

- [x] Unit tests for `OnionmasqNativeGate` (CI)
- [ ] CI assembleDebug + unit tests green
- [ ] Device: Arti + onionmasq plane — connect VPN twice (fresh + restart); confirm no SIGABRT in logcat / tombstones
- [ ] Confirm HEV_SOCKS path unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423be4f8-6f5e-4020-891f-3d36651129d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423be4f8-6f5e-4020-891f-3d36651129d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

